### PR TITLE
Add package-level READMEs

### DIFF
--- a/packages/dynamodb-orm/readme.md
+++ b/packages/dynamodb-orm/readme.md
@@ -1,0 +1,56 @@
+# @schemeless/dynamodb-orm
+
+Utility helpers for building DynamoDB repositories with the AWS Data Mapper. The package keeps table metadata on your entity classes, exposes a cached manager that bootstraps tables on first use, and ships a reusable `DateType` marshaller for ISO string persistence.
+
+## Installation
+
+```bash
+yarn add @schemeless/dynamodb-orm @aws/dynamodb-data-mapper aws-sdk
+```
+
+`aws-sdk` is a peer dependency so you can control credentials and region resolution.
+
+## Define an entity
+
+Use your regular Data Mapper annotations and add the provided `repo` decorator so the helper knows which table and create options to use when initialising the repository.
+
+```ts
+import { attribute, hashKey, table } from '@aws/dynamodb-data-mapper-annotations';
+import { repo, DateType } from '@schemeless/dynamodb-orm';
+
+@table('user-events')
+@repo('user-events', {
+  readCapacityUnits: 5,
+  writeCapacityUnits: 5,
+})
+class UserEvent {
+  @hashKey()
+  id!: string;
+
+  @attribute(DateType)
+  created!: Date;
+
+  @attribute()
+  payload!: Record<string, unknown>;
+}
+```
+
+The decorator stores the table name and creation settings on the entity prototype, and the exported `DateType` converts between JavaScript `Date` objects and ISO8601 strings when writing to DynamoDB.
+
+## Create and reuse a manager
+
+`makeGetDynamoDbManager` wires the AWS client configuration, table prefix, and entity metadata together. The returned function lazily creates a `DynamodbManager` per entity, ensures the table exists, and caches the instance for later calls so subsequent requests reuse the same mapper and repo.
+
+```ts
+import { DynamoDB } from 'aws-sdk';
+import { makeGetDynamoDbManager } from '@schemeless/dynamodb-orm';
+
+const getManager = makeGetDynamoDbManager('dev-', { region: 'us-east-1' });
+
+async function saveEvent(event: UserEvent) {
+  const manager = await getManager(UserEvent);
+  await manager.repo.put(event);
+}
+```
+
+Each `DynamodbManager` exposes a Data Mapper client and the strongly-typed repository wrapper with convenience methods such as `put`, `get`, `query`, and `ensureTableExists` so you can focus on domain logic instead of boilerplate persistence code.

--- a/packages/event-store-adapter-dynamodb/readme.md
+++ b/packages/event-store-adapter-dynamodb/readme.md
@@ -1,0 +1,42 @@
+# @schemeless/event-store-adapter-dynamodb
+
+A DynamoDB-backed implementation of the `IEventStoreRepo` contract. It pairs the AWS Data Mapper with optional S3 offloading so oversized payloads are stored outside the main table while the event store runtime keeps working with plain JavaScript objects.
+
+## Installation
+
+```bash
+yarn add @schemeless/event-store-adapter-dynamodb @aws/dynamodb-data-mapper @aws/dynamodb-data-mapper-annotations aws-sdk
+```
+
+The package expects `aws-sdk` clients for DynamoDB and S3. You can reuse existing credentials, region, or endpoint overrides when constructing those clients.
+
+## Usage
+
+```ts
+import { DynamoDB, S3 } from 'aws-sdk';
+import { EventStoreRepo as EventStoreDynamoRepo } from '@schemeless/event-store-adapter-dynamodb';
+import { makeEventStore } from '@schemeless/event-store';
+
+const dynamodb = new DynamoDB({ region: 'us-east-1' });
+const s3 = new S3({ region: 'us-east-1' });
+
+const repo = new EventStoreDynamoRepo(dynamodb, s3, {
+  tableNamePrefix: 'prod-',
+  s3BucketName: 'my-event-archive',
+  eventStoreTableReadCapacityUnits: 20,
+  eventStoreTableWriteCapacityUnits: 10,
+});
+
+const buildStore = makeEventStore(repo);
+const eventStore = await buildStore(eventFlows);
+```
+
+When `init` runs the repository ensures the DynamoDB table and secondary index exist (unless skipped) and optionally creates the backing S3 bucket. Persisted events larger than ~350KB are automatically serialised to S3 and replaced with a bucket/key reference so your table remains within item size limits.
+
+## Event streaming
+
+`getAllEvents` returns an async iterator that loads pages of item identifiers through a global secondary index, hydrates the full records, resolves S3-backed payloads, and yields events in chronological order. The event store replay helper uses this iterator to rebuild projections consistently across restarts.
+
+## Resetting state
+
+Call `resetStore` to drop and recreate the DynamoDB table. This is handy for integration tests or local development where you need a clean slate between runs.

--- a/packages/event-store-adapter-null/readme.md
+++ b/packages/event-store-adapter-null/readme.md
@@ -1,0 +1,23 @@
+# @schemeless/event-store-adapter-null
+
+A no-op `IEventStoreRepo` implementation. Use it when you want to exercise event flows without touching a database—for example in unit tests or command handlers that you are validating in isolation.
+
+## Installation
+
+```bash
+yarn add @schemeless/event-store-adapter-null
+```
+
+## Usage
+
+```ts
+import { EventStoreRepo as NullRepo } from '@schemeless/event-store-adapter-null';
+import { makeEventStore } from '@schemeless/event-store';
+
+const repo = new NullRepo();
+const eventStore = await makeEventStore(repo)(eventFlows);
+
+await eventStore.receive(flow)({ payload: { /* ... */ } });
+```
+
+The repository exposes the same API surface as the production adapters, but `storeEvents` is a no-op and `resetStore` simply logs that no action is required. Because nothing is persisted you should only use this adapter in tests or ephemeral environments.

--- a/packages/event-store-adapter-typeorm/readme.md
+++ b/packages/event-store-adapter-typeorm/readme.md
@@ -1,0 +1,39 @@
+# @schemeless/event-store-adapter-typeorm
+
+A SQL persistence adapter built on top of TypeORM. It stores events in a simple table, keeps JSON payloads/meta serialised as text, and exposes the `IEventStoreRepo` contract so you can plug it straight into the core runtime.
+
+## Installation
+
+```bash
+yarn add @schemeless/event-store-adapter-typeorm typeorm
+```
+
+Install the database driver you intend to use (for example `sqlite3`, `mysql2`, or `pg`) because TypeORM relies on peer dependencies for transport.
+
+## Usage
+
+```ts
+import { EventStoreRepo as TypeOrmRepo } from '@schemeless/event-store-adapter-typeorm';
+import { makeEventStore } from '@schemeless/event-store';
+
+const repo = new TypeOrmRepo({
+  type: 'postgres',
+  host: 'localhost',
+  port: 5432,
+  username: 'postgres',
+  password: 'postgres',
+  database: 'event_store',
+});
+
+const eventStore = await makeEventStore(repo)(eventFlows, successObservers);
+```
+
+On initialisation the repository creates (or reuses) a TypeORM connection, choosing a slightly different entity shape when targeting SQLite so timestamp precision is preserved. Incoming events are converted into entity instances, payload/meta fields are stringified, and every record is persisted inside a transaction to guarantee consistency.
+
+## Streaming events
+
+`getAllEvents` returns an async iterator that pages through events ordered by `created` and `id`. An optional `startFromId` lets you resume from a checkpoint, and every page is parsed back into plain JavaScript objects before being yielded to the replay subsystem.
+
+## Resetting the store
+
+`resetStore` drops and recreates the schema using TypeORM’s `synchronize(true)` call. For MySQL it also ensures the database exists and uses UTF-8 collation, which keeps integration tests and local development ergonomic.

--- a/packages/event-store-types/readme.md
+++ b/packages/event-store-types/readme.md
@@ -1,0 +1,51 @@
+# @schemeless/event-store-types
+
+Shared TypeScript definitions used by the event store runtime, adapters, and application code. Import these contracts when authoring event flows, observers, or custom persistence layers.
+
+## Installation
+
+```bash
+yarn add @schemeless/event-store-types
+```
+
+## Event primitives
+
+The package defines the shape of event inputs, created events, and the lifecycle metadata that flows through the runtime.
+
+```ts
+import { BaseEventInput, CreatedEvent, EventFlow } from '@schemeless/event-store-types';
+
+const draft: BaseEventInput<{ id: string }> = {
+  payload: { id: '123' },
+};
+
+const eventFlow: EventFlow = {
+  domain: 'user',
+  type: 'registered',
+  receive: (eventStore) => eventStore.receive(eventFlow),
+};
+```
+
+`CreatedEvent` extends the base shape with generated identifiers and timestamps, while `SideEffectsState`, `EventOutputState`, and `EventObserverState` describe the possible outcomes emitted by the runtime.
+
+## Repository contracts
+
+`Repo.types` exposes the `IEventStoreRepo` and `IEventStoreEntity` interfaces. Adapters implement these to integrate with the core runtime.
+
+```ts
+import { IEventStoreRepo } from '@schemeless/event-store-types';
+
+class CustomRepo implements IEventStoreRepo {
+  async init() {}
+  async getAllEvents(pageSize: number) {
+    // return an async iterator of stored events
+  }
+  createEventEntity(event) {
+    return event;
+  }
+  async storeEvents(events) {}
+  async resetStore() {}
+}
+```
+
+The iterator returned by `getAllEvents` yields arrays of `IEventStoreEntity` records. Each record includes identifiers, correlation/causation metadata, and the `created` timestamp so replays can process history in order.

--- a/packages/event-store/readme.md
+++ b/packages/event-store/readme.md
@@ -1,0 +1,82 @@
+# @schemeless/event-store
+
+The runtime core that orchestrates event flow execution, persistence, observer notification, and side-effect retries. It glues your `EventFlow` definitions together with an `IEventStoreRepo` implementation and emits every lifecycle outcome through an observable stream.
+
+## Installation
+
+```bash
+yarn add @schemeless/event-store
+```
+
+You will also need one of the persistence adapters (for example `@schemeless/event-store-adapter-typeorm` or `@schemeless/event-store-adapter-dynamodb`).
+
+## Define event flows
+
+An event flow describes how a domain event is received, validated, applied, and enriched with consequent events or side effects. Each handler is optional, so you can start with a bare minimum and grow behaviour over time.
+
+```ts
+import { EventFlow } from '@schemeless/event-store';
+
+export const userRegisteredFlow: EventFlow = {
+  domain: 'user',
+  type: 'registered',
+  receive: (eventStore) => async (eventInput) =>
+    eventStore.receive(userRegisteredFlow)(eventInput),
+  validate: async (event) => {
+    if (!event.payload.email) {
+      throw new Error('email is required');
+    }
+  },
+  apply: async (event) => {
+    // Update projections, write to read models, etc.
+  },
+};
+```
+
+You can attach additional hooks such as `sideEffect` (retryable asynchronous work) or `createConsequentEvents` (fan out new root events) by setting the corresponding properties on the flow object.
+
+## Build the store
+
+`makeEventStore` wires your repository and flows together, returning queues, a `receive` helper, and a replay function. Success observers are processed on a dedicated queue so long-running reactions do not block the main command pipeline.
+
+```ts
+import { makeEventStore, sideEffectFinishedPromise } from '@schemeless/event-store';
+import { EventStoreRepo as TypeOrmRepo } from '@schemeless/event-store-adapter-typeorm';
+
+const repo = new TypeOrmRepo({ type: 'sqlite', database: ':memory:' });
+const buildStore = makeEventStore(repo);
+
+const eventStore = await buildStore([userRegisteredFlow]);
+
+const [created] = await eventStore.receive(userRegisteredFlow)({
+  payload: { id: '123', email: 'user@example.com' },
+});
+
+await sideEffectFinishedPromise(eventStore); // Wait until the side-effect queue drains.
+```
+
+The returned object exposes:
+
+- `receive` – enqueues events and persists them once every validation step passes.
+- `mainQueue` and `sideEffectQueue` – observable queues that process lifecycle work and retryable side effects.
+- `output$` – an RxJS stream of every processed event with a success, invalid, canceled, or side-effect state.
+- `replay` – streams stored events back through the flows and success observers, enabling projection rebuilds.
+
+## Observers and replay
+
+Register success observers when constructing the store to react to committed events without interfering with the main execution path. During replays the same observer queue is used, so you can reuse the exact logic for live and historical processing.
+
+```ts
+const logObserver = {
+  filters: [{ domain: 'user', type: 'registered' }],
+  priority: 100,
+  apply: async (event) => {
+    console.log('User registered:', event.payload.email);
+  },
+};
+
+const eventStore = await buildStore([userRegisteredFlow], [logObserver]);
+await eventStore.replay();
+```
+
+`replay` batches historical records, ensures each event is re-applied in chronological order, and pushes them through the observer queue so read models stay consistent after deployments or migrations.


### PR DESCRIPTION
## Summary
- add documentation for each workspace package covering installation and usage
- document repository-specific behaviour for the DynamoDB, TypeORM, and null adapters
- describe the exported types and runtime orchestration APIs for easier onboarding

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d168be102083298eaf4ab76e1a91f9