### PR TITLE
chore: add publish workflow and bump versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish Packages
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+          cache: yarn
+
+      - name: Use Yarn 1.x
+        run: corepack prepare yarn@1.22.19 --activate
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build packages
+        run: yarn lerna run prepublish
+
+      - name: Run tests
+        run: yarn test
+
+      - name: Publish packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn publish-all

--- a/packages/dynamodb-orm/package.json
+++ b/packages/dynamodb-orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/dynamodb-orm",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/event-store-adapter-dynamodb/package.json
+++ b/packages/event-store-adapter-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store-adapter-dynamodb",
-  "version": "2.2.0-rc.5",
+  "version": "2.2.0-rc.6",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -25,7 +25,7 @@
   "dependencies": {
     "@aws/dynamodb-data-mapper": "^0.7.3",
     "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
-    "@schemeless/event-store-types": "^2.1.0",
+    "@schemeless/event-store-types": "^2.3.1",
     "debug": "^4.2.0",
     "object-sizeof": "^1.6.1"
   },

--- a/packages/event-store-adapter-null/package.json
+++ b/packages/event-store-adapter-null/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store-adapter-null",
-  "version": "2.2.0-rc.1",
+  "version": "2.2.0-rc.2",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "url": "https://github.com/schemeless/event-store/issues"
   },
   "dependencies": {
-    "@schemeless/event-store-types": "^2.1.0",
+    "@schemeless/event-store-types": "^2.3.1",
     "debug": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/event-store-adapter-typeorm/package.json
+++ b/packages/event-store-adapter-typeorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store-adapter-typeorm",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "url": "https://github.com/schemeless/event-store/issues"
   },
   "dependencies": {
-    "@schemeless/event-store-types": "^2.3.0",
+    "@schemeless/event-store-types": "^2.3.1",
     "debug": "^4.2.0",
     "typeorm": "^0.2.29"
   },

--- a/packages/event-store-types/package.json
+++ b/packages/event-store-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store-types",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/event-store/package.json
+++ b/packages/event-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "url": "https://github.com/schemeless/event-store/issues"
   },
   "dependencies": {
-    "@schemeless/event-store-types": "^2.3.0",
+    "@schemeless/event-store-types": "^2.3.1",
     "better-queue": "^3.8.10",
     "debug": "^4.2.0",
     "ramda": "^0.27.1",
@@ -30,8 +30,8 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@schemeless/event-store-adapter-dynamodb": "^2.2.0-rc.3",
-    "@schemeless/event-store-adapter-typeorm": "^2.3.0",
+    "@schemeless/event-store-adapter-dynamodb": "^2.2.0-rc.6",
+    "@schemeless/event-store-adapter-typeorm": "^2.3.1",
     "@types/better-queue": "^3.8.2",
     "@types/debug": "^4.1.5",
     "@types/jest": "^26.0.15",


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds, tests, and publishes the packages on demand or when a release is published
- bump the workspace package versions to prepare the next npm release and align cross-package dependency ranges

## Testing
- yarn test *(fails: TS2322 in packages/event-store/src/util/completeOn.operator.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d16c6bf9008329810f4ca33bdc7d27