### PR TITLE
chore: align package versions

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "independent",
+  "version": "2.4.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/dynamodb-orm/package.json
+++ b/packages/dynamodb-orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/dynamodb-orm",
-  "version": "0.1.11",
+  "version": "2.4.0",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/event-store-adapter-dynamodb/package.json
+++ b/packages/event-store-adapter-dynamodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store-adapter-dynamodb",
-  "version": "2.2.0-rc.6",
+  "version": "2.4.0",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -25,7 +25,7 @@
   "dependencies": {
     "@aws/dynamodb-data-mapper": "^0.7.3",
     "@aws/dynamodb-data-mapper-annotations": "^0.7.3",
-    "@schemeless/event-store-types": "^2.3.1",
+    "@schemeless/event-store-types": "^2.4.0",
     "debug": "^4.2.0",
     "object-sizeof": "^1.6.1"
   },

--- a/packages/event-store-adapter-null/package.json
+++ b/packages/event-store-adapter-null/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store-adapter-null",
-  "version": "2.2.0-rc.2",
+  "version": "2.4.0",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "url": "https://github.com/schemeless/event-store/issues"
   },
   "dependencies": {
-    "@schemeless/event-store-types": "^2.3.1",
+    "@schemeless/event-store-types": "^2.4.0",
     "debug": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/event-store-adapter-typeorm/package.json
+++ b/packages/event-store-adapter-typeorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store-adapter-typeorm",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "url": "https://github.com/schemeless/event-store/issues"
   },
   "dependencies": {
-    "@schemeless/event-store-types": "^2.3.1",
+    "@schemeless/event-store-types": "^2.4.0",
     "debug": "^4.2.0",
     "typeorm": "^0.2.29"
   },

--- a/packages/event-store-types/package.json
+++ b/packages/event-store-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store-types",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/event-store/package.json
+++ b/packages/event-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "url": "https://github.com/schemeless/event-store/issues"
   },
   "dependencies": {
-    "@schemeless/event-store-types": "^2.3.1",
+    "@schemeless/event-store-types": "^2.4.0",
     "better-queue": "^3.8.10",
     "debug": "^4.2.0",
     "ramda": "^0.27.1",
@@ -30,8 +30,8 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@schemeless/event-store-adapter-dynamodb": "^2.2.0-rc.6",
-    "@schemeless/event-store-adapter-typeorm": "^2.3.1",
+    "@schemeless/event-store-adapter-dynamodb": "^2.4.0",
+    "@schemeless/event-store-adapter-typeorm": "^2.4.0",
     "@types/better-queue": "^3.8.2",
     "@types/debug": "^4.1.5",
     "@types/jest": "^26.0.15",


### PR DESCRIPTION
## Summary
- switch the monorepo to a fixed 2.4.0 release in `lerna.json`
- bump each published package to 2.4.0 and update internal dependency ranges to match

## Testing
- npx yarn@1.22.19 test

------
https://chatgpt.com/codex/tasks/task_e_68d2b3495c6c83299e843952baccdceb