### PR TITLE
feat: add prisma event store adapter

### DIFF
--- a/packages/event-store-adapter-prisma/jest.config.js
+++ b/packages/event-store-adapter-prisma/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  moduleNameMapper: {
+    '^@schemeless/(.*)$': '<rootDir>/../$1/src',
+  },
+};

--- a/packages/event-store-adapter-prisma/package.json
+++ b/packages/event-store-adapter-prisma/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@schemeless/event-store-adapter-prisma",
+  "version": "2.4.0",
+  "typescript:main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "dev": "node_modules/.bin/tsc -w",
+    "clean": "node_modules/.bin/rimraf ./dist",
+    "test": "node_modules/.bin/jest --passWithNoTests",
+    "compile": "yarn run clean && node_modules/.bin/tsc",
+    "prepublish": "yarn run clean && yarn run compile"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/schemeless/event-store.git"
+  },
+  "keywords": [],
+  "author": "akinoniku",
+  "bugs": {
+    "url": "https://github.com/schemeless/event-store/issues"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.17.0",
+    "@schemeless/event-store-types": "^2.4.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.15",
+    "@types/node": "^14.14.7",
+    "jest": "^26.6.3",
+    "prisma": "^5.17.0",
+    "rimraf": "^3.0.2",
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.0.5"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/event-store-adapter-prisma/prisma/schema.prisma
+++ b/packages/event-store-adapter-prisma/prisma/schema.prisma
@@ -1,0 +1,25 @@
+// Test schema for @schemeless/event-store-adapter-prisma
+// This schema is used exclusively for the automated test suite.
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model EventStoreEntity {
+  id            String   @id
+  domain        String
+  type          String
+  meta          String?
+  payload       String
+  identifier    String?
+  correlationId String?
+  causationId   String?
+  created       DateTime
+
+  @@index([created, id])
+}

--- a/packages/event-store-adapter-prisma/readme.md
+++ b/packages/event-store-adapter-prisma/readme.md
@@ -1,0 +1,45 @@
+# `@schemeless/event-store-adapter-prisma`
+
+Official Prisma adapter for the Schemeless Event Store. This package lets you use a Prisma Client instance as the persistence layer behind `@schemeless/event-store`, embracing Prisma's schema-first workflow while reusing the existing event sourcing APIs.
+
+## Installation
+
+```bash
+yarn add @schemeless/event-store-adapter-prisma @prisma/client
+yarn add -D prisma
+```
+
+## Setup
+
+1. Add the `EventStoreEntity` model to your `prisma/schema.prisma` file. A ready-to-copy example lives at [`schema.prisma.example`](./schema.prisma.example) and is also exported from [`src/schema.prisma.example`](./src/schema.prisma.example) for programmatic access.
+2. Run Prisma migrations to apply the schema to your database:
+   - During development: `npx prisma migrate dev`
+   - In production: `npx prisma migrate deploy`
+3. Generate the Prisma Client that this adapter expects:
+
+```bash
+npx prisma generate
+```
+
+After these steps the generated client will include the `eventStoreEntity` model used by the adapter.
+
+## Usage
+
+```ts
+import { PrismaClient } from '@prisma/client';
+import { makeEventStore } from '@schemeless/event-store';
+import { EventStoreRepo } from '@schemeless/event-store-adapter-prisma';
+
+const prisma = new PrismaClient();
+const repo = new EventStoreRepo(prisma);
+
+await repo.init();
+
+const eventStore = await makeEventStore({
+  repo,
+});
+
+// Store new events through the Event Store APIs as usual
+```
+
+The adapter never runs migrations or schema updates for you. Make sure your deployment pipeline runs the appropriate `prisma migrate` or `prisma db push` commands before the application starts.

--- a/packages/event-store-adapter-prisma/schema.prisma.example
+++ b/packages/event-store-adapter-prisma/schema.prisma.example
@@ -1,0 +1,24 @@
+// In your own prisma/schema.prisma file
+
+datasource db {
+  provider = "postgresql" // or "mysql", "sqlite", etc.
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model EventStoreEntity {
+  id            String   @id @db.VarChar(36)
+  domain        String   @db.VarChar(15)
+  type          String   @db.VarChar(32)
+  meta          String?  @db.Text
+  payload       String   @db.Text
+  identifier    String?  @db.VarChar(64)
+  correlationId String?  @db.VarChar(36)
+  causationId   String?  @db.VarChar(36)
+  created       DateTime @db.Timestamp(6)
+
+  @@index([created, id]) // For ordered replay
+}

--- a/packages/event-store-adapter-prisma/src/EventStore.repo.test.ts
+++ b/packages/event-store-adapter-prisma/src/EventStore.repo.test.ts
@@ -1,0 +1,130 @@
+import * as path from 'path';
+import { promisify } from 'util';
+import { execFile } from 'child_process';
+import { promises as fs } from 'fs';
+import { pathToFileURL } from 'url';
+
+import { PrismaClient } from '@prisma/client';
+import type { CreatedEvent, IEventStoreEntity } from '@schemeless/event-store-types';
+
+import { EventStoreRepo } from './EventStore.repo';
+
+const execFileAsync = promisify(execFile);
+const packageRoot = path.resolve(__dirname, '..');
+const schemaPath = path.join(packageRoot, 'prisma', 'schema.prisma');
+const prismaBinary =
+  process.platform === 'win32'
+    ? path.join(packageRoot, 'node_modules', '.bin', 'prisma.cmd')
+    : path.join(packageRoot, 'node_modules', '.bin', 'prisma');
+const databaseFile = path.join(packageRoot, 'prisma', 'test.db');
+const databaseUrl = pathToFileURL(databaseFile).toString();
+const prismaCliOptions = {
+  cwd: packageRoot,
+  env: {
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+  },
+};
+
+const makeEvent = (index: number): CreatedEvent<any, any> => ({
+  id: `event-${index.toString().padStart(6, '0')}`,
+  domain: 'test',
+  type: 'test',
+  payload: { id: index },
+  meta: { index },
+  created: new Date(Date.now() + index * 1000),
+});
+
+describe('EventStoreRepo (Prisma)', () => {
+  let prisma: PrismaClient;
+  let repo: EventStoreRepo;
+
+  beforeAll(async () => {
+    process.env.DATABASE_URL = databaseUrl;
+
+    await execFileAsync(prismaBinary, ['generate', '--schema', schemaPath], prismaCliOptions);
+
+    await execFileAsync(prismaBinary, ['db', 'push', '--schema', schemaPath, '--skip-generate'], prismaCliOptions);
+
+    prisma = new PrismaClient();
+    repo = new EventStoreRepo(prisma);
+    await repo.init();
+  });
+
+  beforeEach(async () => {
+    await repo.resetStore();
+  });
+
+  afterAll(async () => {
+    await repo.resetStore();
+    await prisma.$disconnect();
+    await fs.rm(databaseFile, { force: true });
+  });
+
+  it('creates a Prisma data payload from a created event', () => {
+    const created: CreatedEvent<any, any> = {
+      id: 'event-1',
+      domain: 'test',
+      type: 'created',
+      payload: { foo: 'bar' },
+      meta: { requestId: '123' },
+      identifier: 'user-1',
+      correlationId: 'corr-1',
+      causationId: 'cause-1',
+      created: new Date(),
+    };
+
+    const entity = repo.createEventEntity(created);
+
+    expect(entity).toMatchObject({
+      id: created.id,
+      domain: created.domain,
+      type: created.type,
+      identifier: created.identifier,
+      correlationId: created.correlationId,
+      causationId: created.causationId,
+    });
+    expect(entity.payload).toBe(JSON.stringify(created.payload));
+    expect(entity.meta).toBe(JSON.stringify(created.meta));
+  });
+
+  it('persists and replays events in order', async () => {
+    const eventsToStore = Array.from({ length: 120 }, (_, index) => makeEvent(index));
+
+    await repo.storeEvents(eventsToStore);
+
+    const iterator = await repo.getAllEvents(25);
+    const received: IEventStoreEntity[] = [];
+
+    for await (const batch of iterator) {
+      received.push(...batch);
+    }
+
+    expect(received).toHaveLength(eventsToStore.length);
+    const isSorted = received.every((event, index, list) => {
+      if (index === list.length - 1) {
+        return true;
+      }
+
+      return list[index + 1].created >= event.created;
+    });
+    expect(isSorted).toBe(true);
+  });
+
+  it('continues replay from a provided event id', async () => {
+    const eventsToStore = Array.from({ length: 75 }, (_, index) => makeEvent(index));
+    await repo.storeEvents(eventsToStore);
+
+    const stopAt = eventsToStore[29];
+
+    const resumedIterator = await repo.getAllEvents(20, stopAt.id);
+    const resumed: IEventStoreEntity[] = [];
+
+    for await (const batch of resumedIterator) {
+      resumed.push(...batch);
+    }
+
+    expect(resumed).toHaveLength(eventsToStore.length - 30);
+    expect(resumed[0].id).toBe(eventsToStore[30].id);
+  });
+});

--- a/packages/event-store-adapter-prisma/src/EventStore.repo.ts
+++ b/packages/event-store-adapter-prisma/src/EventStore.repo.ts
@@ -1,0 +1,73 @@
+import type { CreatedEvent, IEventStoreEntity, IEventStoreRepo } from '@schemeless/event-store-types';
+import type { Prisma, PrismaClient } from '@prisma/client';
+import { EventStoreIterator } from './EventStoreIterator';
+
+const serializePayload = (payload: unknown): string => JSON.stringify(payload ?? null);
+const serializeMeta = (meta: unknown): string | null | undefined => {
+  if (meta === undefined) {
+    return undefined;
+  }
+
+  return meta === null ? null : JSON.stringify(meta);
+};
+
+type PrismaEventStoreEntityCreateInput = Omit<Prisma.EventStoreEntityCreateInput, 'created'> & {
+  created: Date;
+};
+
+type PrismaEventStoreEntity = PrismaEventStoreEntityCreateInput & IEventStoreEntity<any, any>;
+
+export class EventStoreRepo implements IEventStoreRepo {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async init(): Promise<void> {
+    // Prisma manages connections on client instantiation.
+  }
+
+  async getAllEvents(
+    pageSize: number = 100,
+    startFromId?: string
+  ): Promise<AsyncIterableIterator<IEventStoreEntity[]>> {
+    return new EventStoreIterator(this.prisma, pageSize, startFromId);
+  }
+
+  createEventEntity(event: CreatedEvent<any>): PrismaEventStoreEntity {
+    const { id, domain, type, payload, meta, created, correlationId, causationId, identifier } = event;
+
+    const entity: PrismaEventStoreEntity = {
+      id,
+      domain,
+      type,
+      created,
+      payload: serializePayload(payload),
+      identifier: identifier ?? null,
+      correlationId: correlationId ?? null,
+      causationId: causationId ?? null,
+    };
+
+    const serializedMeta = serializeMeta(meta);
+    if (serializedMeta !== undefined) {
+      entity.meta = serializedMeta;
+    }
+
+    return entity;
+  }
+
+  async storeEvents(events: CreatedEvent<any>[]): Promise<void> {
+    if (!events.length) {
+      return;
+    }
+
+    const dataToCreate = events.map((event) => this.createEventEntity(event));
+
+    await this.prisma.$transaction(async (tx) => {
+      for (const data of dataToCreate) {
+        await tx.eventStoreEntity.create({ data });
+      }
+    });
+  }
+
+  async resetStore(): Promise<void> {
+    await this.prisma.$executeRawUnsafe('DELETE FROM "EventStoreEntity"');
+  }
+}

--- a/packages/event-store-adapter-prisma/src/EventStoreIterator.ts
+++ b/packages/event-store-adapter-prisma/src/EventStoreIterator.ts
@@ -1,0 +1,55 @@
+import type { PrismaClient } from '@prisma/client';
+import type { IEventStoreEntity } from '@schemeless/event-store-types';
+
+type PrismaFindManyResult = ReturnType<PrismaClient['eventStoreEntity']['findMany']>;
+type PrismaEventStoreEntityArray = PrismaFindManyResult extends Promise<infer U> ? U : never;
+type PrismaEventStoreEntity = PrismaEventStoreEntityArray extends Array<infer U> ? U : never;
+
+const deserializeEvent = (entity: PrismaEventStoreEntity): IEventStoreEntity<any, any> => ({
+  id: entity.id,
+  domain: entity.domain,
+  type: entity.type,
+  identifier: entity.identifier ?? undefined,
+  correlationId: entity.correlationId ?? undefined,
+  causationId: entity.causationId ?? undefined,
+  created: entity.created,
+  payload: JSON.parse(entity.payload),
+  meta: entity.meta != null ? JSON.parse(entity.meta) : undefined,
+});
+
+export class EventStoreIterator implements AsyncIterableIterator<IEventStoreEntity[]> {
+  private currentPage = 0;
+
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly pageSize: number,
+    private readonly startFromId?: string
+  ) {}
+
+  async next(): Promise<IteratorResult<IEventStoreEntity[]>> {
+    const results = await this.prisma.eventStoreEntity.findMany({
+      take: this.pageSize,
+      skip: this.pageSize * this.currentPage,
+      orderBy: [{ created: 'asc' }, { id: 'asc' }],
+      where: this.startFromId
+        ? {
+            id: {
+              gt: this.startFromId,
+            },
+          }
+        : undefined,
+    });
+
+    this.currentPage += 1;
+
+    if (!results.length) {
+      return { done: true, value: undefined };
+    }
+
+    return { done: false, value: results.map(deserializeEvent) };
+  }
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<IEventStoreEntity[]> {
+    return this;
+  }
+}

--- a/packages/event-store-adapter-prisma/src/index.ts
+++ b/packages/event-store-adapter-prisma/src/index.ts
@@ -1,0 +1,2 @@
+export { EventStoreRepo } from './EventStore.repo';
+export { EventStoreIterator } from './EventStoreIterator';

--- a/packages/event-store-adapter-prisma/src/schema.prisma.example
+++ b/packages/event-store-adapter-prisma/src/schema.prisma.example
@@ -1,0 +1,24 @@
+// In your own prisma/schema.prisma file
+
+datasource db {
+  provider = "postgresql" // or "mysql", "sqlite", etc.
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model EventStoreEntity {
+  id            String   @id @db.VarChar(36)
+  domain        String   @db.VarChar(15)
+  type          String   @db.VarChar(32)
+  meta          String?  @db.Text
+  payload       String   @db.Text
+  identifier    String?  @db.VarChar(64)
+  correlationId String?  @db.VarChar(36)
+  causationId   String?  @db.VarChar(36)
+  created       DateTime @db.Timestamp(6)
+
+  @@index([created, id]) // For ordered replay
+}

--- a/packages/event-store-adapter-prisma/tsconfig.json
+++ b/packages/event-store-adapter-prisma/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "target": "es6",
+    "lib": ["es7"],
+    "module": "commonjs",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "outDir": "./dist",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
+    "strictPropertyInitialization": false,
+    "baseUrl": ".",
+    "paths": {
+      "@schemeless/*": ["../*/src"]
+    }
+  },
+  "exclude": ["node_modules"],
+  "include": ["src/**/*.ts"]
+}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Schemeless Event Store
 
-A batteries-included event sourcing toolkit for Node.js services. The monorepo provides the core event store runtime, strongly typed definitions for authoring event flows, and persistence adapters that let you capture and replay events through DynamoDB, TypeORM-backed SQL databases, or in-memory stubs.
+A batteries-included event sourcing toolkit for Node.js services. The monorepo provides the core event store runtime, strongly typed definitions for authoring event flows, and persistence adapters that let you capture and replay events through DynamoDB, Prisma-managed SQL databases, TypeORM-backed SQL databases, MikroORM, or in-memory stubs.
 
 ## Why Schemeless?
 
@@ -30,6 +30,7 @@ Adapters implement the `IEventStoreRepo` contract so the runtime can initialise 
 - `@schemeless/event-store` – Core runtime that exposes `makeEventStore`, queues, and the `output$` observable stream for monitoring progress ([makeEventStore.ts](packages/event-store/src/makeEventStore.ts#L17-L54), [EventStore.types.ts](packages/event-store/src/EventStore.types.ts#L13-L28)).
 - `@schemeless/event-store-types` – Shared TypeScript definitions for events, event flows, observers, and repository interfaces ([EventStore.types.ts](packages/event-store-types/src/EventStore.types.ts#L1-L78), [Repo.types.ts](packages/event-store-types/src/Repo.types.ts#L1-L26)).
 - `@schemeless/event-store-adapter-typeorm` – SQL-backed repository that persists events through TypeORM, supports SQLite quirks, and resets schemas via migrations ([EventStore.repo.ts](packages/event-store-adapter-typeorm/src/EventStore.repo.ts#L1-L65)).
+- `@schemeless/event-store-adapter-prisma` – Prisma ORM adapter that consumes an existing `PrismaClient`, persists events inside interactive transactions, and streams ordered history without running schema migrations for you ([EventStore.repo.ts](packages/event-store-adapter-prisma/src/EventStore.repo.ts#L1-L64)).
 - `@schemeless/event-store-adapter-mikroorm` – MikroORM-based SQL adapter that wraps transactions, streams paginated history, and works across PostgreSQL, MySQL, SQLite, and other MikroORM drivers ([EventStore.repo.ts](packages/event-store-adapter-mikroorm/src/EventStore.repo.ts#L1-L97)).
 - `@schemeless/event-store-adapter-dynamodb` – DynamoDB + S3 repository that transparently offloads oversized payloads while keeping table size under AWS limits ([EventStore.dynamodb.repo.ts](packages/event-store-adapter-dynamodb/src/EventStore.dynamodb.repo.ts#L1-L97)).
 - `@schemeless/event-store-adapter-null` – No-op adapter useful for unit tests and dry runs where persistence is unnecessary ([EventStore.repo.ts](packages/event-store-adapter-null/src/EventStore.repo.ts#L1-L19)).
@@ -49,7 +50,7 @@ For long-running services, `replay` rehydrates projections by running stored eve
 packages/
   event-store/                 Core runtime implementation
   event-store-types/           Shared type definitions
-  event-store-adapter-*/       Persistence implementations (TypeORM, DynamoDB, null)
+  event-store-adapter-*/       Persistence implementations (Prisma, TypeORM, DynamoDB, null)
   dynamodb-orm/                AWS Data Mapper helpers
 examples/
   example-domain-pacakges/     Sample event flows and domains

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,6 +1519,47 @@
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
 
+"@prisma/client@^5.17.0":
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-5.22.0.tgz#da1ca9c133fbefe89e0da781c75e1c59da5f8802"
+  integrity sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==
+
+"@prisma/debug@5.22.0":
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-5.22.0.tgz#58af56ed7f6f313df9fb1042b6224d3174bbf412"
+  integrity sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==
+
+"@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2":
+  version "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz#d534dd7235c1ba5a23bacd5b92cc0ca3894c28f4"
+  integrity sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==
+
+"@prisma/engines@5.22.0":
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-5.22.0.tgz#28f3f52a2812c990a8b66eb93a0987816a5b6d84"
+  integrity sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==
+  dependencies:
+    "@prisma/debug" "5.22.0"
+    "@prisma/engines-version" "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2"
+    "@prisma/fetch-engine" "5.22.0"
+    "@prisma/get-platform" "5.22.0"
+
+"@prisma/fetch-engine@5.22.0":
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz#4fb691b483a450c5548aac2f837b267dd50ef52e"
+  integrity sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==
+  dependencies:
+    "@prisma/debug" "5.22.0"
+    "@prisma/engines-version" "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2"
+    "@prisma/get-platform" "5.22.0"
+
+"@prisma/get-platform@5.22.0":
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-5.22.0.tgz#fc675bc9d12614ca2dade0506c9c4a77e7dddacd"
+  integrity sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==
+  dependencies:
+    "@prisma/debug" "5.22.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.6"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"
@@ -3904,7 +3945,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.1.2:
+fsevents@2.3.3, fsevents@^2.1.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -7073,6 +7114,15 @@ pretty-quick@^3.1.0:
     picocolors "^1.0.0"
     picomatch "^3.0.1"
     tslib "^2.6.2"
+
+prisma@^5.17.0:
+  version "5.22.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-5.22.0.tgz#1f6717ff487cdef5f5799cc1010459920e2e6197"
+  integrity sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==
+  dependencies:
+    "@prisma/engines" "5.22.0"
+  optionalDependencies:
+    fsevents "2.3.3"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Summary
- add the @schemeless/event-store-adapter-prisma workspace with a Prisma-backed EventStoreRepo implementation and iterator
- include Prisma schema examples, a SQLite test schema, and documentation for installing and using the adapter
- wire up Jest tests that exercise persistence, replay, and serialization using a generated Prisma Client

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d37acd605c8329aa8ea2d6a2e7fa0b