### PR TITLE
Fix causation id fallback and add regression test

### DIFF
--- a/packages/event-store/src/operators/defaultEventCreator.test.ts
+++ b/packages/event-store/src/operators/defaultEventCreator.test.ts
@@ -1,0 +1,14 @@
+import { defaultEventCreator } from './defaultEventCreator';
+
+describe('defaultEventCreator', () => {
+  it('uses provided causationId when no causal event is supplied', () => {
+    const event = defaultEventCreator({
+      domain: 'Test',
+      type: 'TestEvent',
+      payload: { value: 1 },
+      causationId: 'manual-id',
+    });
+
+    expect(event.causationId).toBe('manual-id');
+  });
+});

--- a/packages/event-store/src/operators/defaultEventCreator.ts
+++ b/packages/event-store/src/operators/defaultEventCreator.ts
@@ -1,10 +1,10 @@
 import type { BaseEvent, CreatedEvent } from '@schemeless/event-store-types';
 import { getUlid } from '../util/ulid';
 
-const dateDefault = (date: string | Date | undefined): Date =>{
-  if (!date) return new Date()
-  return typeof date === 'string' ? new Date(date) : date
-}
+const dateDefault = (date: string | Date | undefined): Date => {
+  if (!date) return new Date();
+  return typeof date === 'string' ? new Date(date) : date;
+};
 
 export function defaultEventCreator<Payload>(
   eventArgs: BaseEvent<Payload>,
@@ -14,10 +14,10 @@ export function defaultEventCreator<Payload>(
   return {
     ...eventArgs,
     id,
-    causationId: eventArgs.causationId || causalEvent ? causalEvent.id : undefined,
+    causationId: eventArgs.causationId ?? (causalEvent ? causalEvent.id : undefined),
     correlationId: eventArgs.correlationId || (causalEvent ? causalEvent.correlationId || causalEvent.id : id),
     identifier: eventArgs.identifier || (causalEvent ? causalEvent.identifier : undefined),
 
-    created: dateDefault(eventArgs.created)
+    created: dateDefault(eventArgs.created),
   };
 }


### PR DESCRIPTION
## Summary
- fix `defaultEventCreator` so it only falls back to a causal event id when none was provided explicitly
- add a regression test covering manual causation ids on root events

## Testing
- yarn test *(fails: missing @schemeless/event-store-types type declarations in ts-jest)*
- yarn workspace @schemeless/event-store test -- operators/defaultEventCreator.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d5e20e7768832982eacef69df7f379