### PR TITLE
refactor: inject MikroORM entity manager into event store repo

### DIFF
--- a/packages/event-store-adapter-mikroorm/package.json
+++ b/packages/event-store-adapter-mikroorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schemeless/event-store-adapter-mikroorm",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "typescript:main": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/event-store-adapter-mikroorm/src/EventStore.test.ts
+++ b/packages/event-store-adapter-mikroorm/src/EventStore.test.ts
@@ -3,15 +3,8 @@ import 'reflect-metadata';
 import type { CreatedEvent } from '@schemeless/event-store-types';
 import { MikroORM } from '@mikro-orm/core';
 import { SqliteDriver } from '@mikro-orm/sqlite';
+import { EventStoreEntity } from './EventStore.entity';
 import { EventStoreRepo } from './EventStore.repo';
-
-type TestOptions = Parameters<typeof MikroORM.init>[0];
-
-const makeSqliteOptions = (): TestOptions => ({
-  driver: SqliteDriver,
-  dbName: ':memory:',
-  entities: [],
-});
 
 const makeEvent = (num: number, overrides: Partial<CreatedEvent<any>> = {}): CreatedEvent<any> => {
   const created = new Date(Date.now() + num * 1000);
@@ -26,118 +19,106 @@ const makeEvent = (num: number, overrides: Partial<CreatedEvent<any>> = {}): Cre
   } as CreatedEvent<any>;
 };
 
-const closeRepo = async (repo: EventStoreRepo) => {
-  const orm = (repo as unknown as { orm?: MikroORM }).orm;
-  if (orm) {
-    await orm.close(true);
-  }
-};
-
 describe('EventStoreRepo (MikroORM)', () => {
+  let orm: MikroORM;
+  let repo: EventStoreRepo;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      driver: SqliteDriver,
+      dbName: ':memory:',
+      entities: [EventStoreEntity],
+    });
+    await orm.getSchemaGenerator().createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    const cleanupEm = orm.em.fork();
+    await cleanupEm.nativeDelete(EventStoreEntity, {});
+    repo = new EventStoreRepo(orm.em);
+  });
+
   it('initialises the schema and returns an empty iterator', async () => {
-    const repo = new EventStoreRepo(makeSqliteOptions());
+    await expect(repo.init()).resolves.toBeUndefined();
 
-    try {
-      await expect(repo.init()).resolves.not.toThrow();
-
-      const iterator = await repo.getAllEvents(50);
-      const first = await iterator.next();
-      expect(first.done).toBe(true);
-      expect(first.value).toBeUndefined();
-    } finally {
-      await closeRepo(repo);
-    }
+    const iterator = await repo.getAllEvents(50);
+    const first = await iterator.next();
+    expect(first.done).toBe(true);
+    expect(first.value).toBeUndefined();
   });
 
   it('persists and retrieves events in order', async () => {
-    const repo = new EventStoreRepo(makeSqliteOptions());
     const events = Array.from({ length: 50 }, (_, index) => makeEvent(index));
 
-    try {
-      await repo.storeEvents(events);
+    await repo.storeEvents(events);
 
-      const iterator = await repo.getAllEvents(10);
-      const retrieved: CreatedEvent<any>[] = [];
+    const iterator = await repo.getAllEvents(10);
+    const retrieved: CreatedEvent<any>[] = [];
 
-      for await (const batch of iterator) {
-        retrieved.push(...batch);
-      }
-
-      expect(retrieved).toHaveLength(events.length);
-      expect(retrieved.map((event) => event.id)).toEqual(events.map((event) => event.id));
-      expect(retrieved.every((event, index) => event.created.getTime() === events[index].created.getTime())).toBe(true);
-      expect(
-        retrieved.every((event, index) => (event.meta as any)?.attempt === (events[index].meta as any)?.attempt)
-      ).toBe(true);
-      expect(retrieved.every((event, index) => event.payload.id === events[index].payload.id)).toBe(true);
-    } finally {
-      await closeRepo(repo);
+    for await (const batch of iterator) {
+      retrieved.push(...batch);
     }
+
+    expect(retrieved).toHaveLength(events.length);
+    expect(retrieved.map((event) => event.id)).toEqual(events.map((event) => event.id));
+    expect(retrieved.every((event, index) => event.created.getTime() === events[index].created.getTime())).toBe(true);
+    expect(
+      retrieved.every((event, index) => (event.meta as any)?.attempt === (events[index].meta as any)?.attempt)
+    ).toBe(true);
+    expect(retrieved.every((event, index) => event.payload.id === events[index].payload.id)).toBe(true);
   });
 
   it('supports pagination and startFromId offsets', async () => {
-    const repo = new EventStoreRepo(makeSqliteOptions());
     const events = Array.from({ length: 30 }, (_, index) => makeEvent(index));
 
-    try {
-      await repo.storeEvents(events);
+    await repo.storeEvents(events);
 
-      const startFrom = events[9];
-      const iterator = await repo.getAllEvents(5, startFrom.id);
-      const resumed: CreatedEvent<any>[] = [];
+    const startFrom = events[9];
+    const iterator = await repo.getAllEvents(5, startFrom.id);
+    const resumed: CreatedEvent<any>[] = [];
 
-      for await (const batch of iterator) {
-        resumed.push(...batch);
-      }
-
-      expect(resumed).toHaveLength(events.length - 10);
-      expect(resumed[0].id).toBe(events[10].id);
-      expect(resumed[resumed.length - 1].id).toBe(events[events.length - 1].id);
-    } finally {
-      await closeRepo(repo);
+    for await (const batch of iterator) {
+      resumed.push(...batch);
     }
+
+    expect(resumed).toHaveLength(events.length - 10);
+    expect(resumed[0].id).toBe(events[10].id);
+    expect(resumed[resumed.length - 1].id).toBe(events[events.length - 1].id);
   });
 
   it('wraps writes in a transaction and rolls back on failure', async () => {
-    const repo = new EventStoreRepo(makeSqliteOptions());
+    const initial = makeEvent(0);
+    await repo.storeEvents([initial]);
 
-    try {
-      const initial = makeEvent(0);
-      await repo.storeEvents([initial]);
+    const duplicateId = 'duplicate-id';
+    const failingBatch = [makeEvent(1, { id: duplicateId }), makeEvent(2, { id: duplicateId })];
 
-      const duplicateId = 'duplicate-id';
-      const failingBatch = [makeEvent(1, { id: duplicateId }), makeEvent(2, { id: duplicateId })];
+    await expect(repo.storeEvents(failingBatch)).rejects.toBeInstanceOf(Error);
 
-      await expect(repo.storeEvents(failingBatch)).rejects.toBeInstanceOf(Error);
-
-      const iterator = await repo.getAllEvents(10);
-      const stored: CreatedEvent<any>[] = [];
-      for await (const batch of iterator) {
-        stored.push(...batch);
-      }
-
-      expect(stored).toHaveLength(1);
-      expect(stored[0].id).toBe(initial.id);
-    } finally {
-      await closeRepo(repo);
+    const iterator = await repo.getAllEvents(10);
+    const stored: CreatedEvent<any>[] = [];
+    for await (const batch of iterator) {
+      stored.push(...batch);
     }
+
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe(initial.id);
   });
 
-  it('drops and recreates the schema when resetStore is called', async () => {
-    const repo = new EventStoreRepo(makeSqliteOptions());
+  it('throws when resetStore is called because schema management is external', async () => {
+    await repo.storeEvents([makeEvent(0), makeEvent(1)]);
 
-    try {
-      await repo.storeEvents([makeEvent(0), makeEvent(1)]);
+    await expect(repo.resetStore()).rejects.toThrow(
+      'EventStoreRepo no longer manages schema. Schema reset should be handled by the application-level ORM instance.'
+    );
 
-      await repo.resetStore();
+    const iterator = await repo.getAllEvents(10);
+    const first = await iterator.next();
 
-      const iterator = await repo.getAllEvents(10);
-      const first = await iterator.next();
-
-      expect(first.done).toBe(true);
-      expect(first.value).toBeUndefined();
-    } finally {
-      await closeRepo(repo);
-    }
+    expect(first.done).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- refactor EventStoreRepo to accept an externally managed EntityManager, using forked contexts for queries and writes and throwing when resetStore is invoked
- rewrite the MikroORM adapter tests to bootstrap MikroORM in the harness and validate pagination, transactional guarantees, and the new resetStore behaviour
- add a migration guide and updated usage docs in the README and bump the package version to 2.5.0

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d73ee454b08329b25049ad0abd7e1e