### PR TITLE
feat: add React Native variant of event store

### DIFF
--- a/packages/event-store-react-native/jest.config.js
+++ b/packages/event-store-react-native/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  moduleNameMapper: {
+    '^@schemeless/(.*)$': '<rootDir>/../$1/src',
+  },
+};

--- a/packages/event-store-react-native/package.json
+++ b/packages/event-store-react-native/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@schemeless/event-store-react-native",
+  "version": "2.4.3",
+  "typescript:main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "dev": "node_modules/.bin/tsc -w",
+    "clean": "node_modules/.bin/rimraf ./dist",
+    "test": "node_modules/.bin/jest --passWithNoTests",
+    "compile": "yarn run clean && node_modules/.bin/tsc",
+    "prepublish": "yarn run clean && yarn run compile"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/schemeless/event-store.git"
+  },
+  "keywords": [
+    "react-native",
+    "event-store"
+  ],
+  "author": "akinoniku",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@schemeless/event-store-types": "^2.4.3",
+    "react-native-better-queue": "^0.1.1",
+    "debug": "^4.2.0",
+    "ramda": "^0.27.1",
+    "rxjs": "^7.5.5",
+    "ulid": "^2.3.0",
+    "uuid": "^8.3.1"
+  },
+  "devDependencies": {
+    "@types/better-queue": "^3.8.2",
+    "@types/ramda": "^0.27.32",
+    "@types/uuid": "^8.3.0",
+    "jest": "^26.6.3",
+    "rimraf": "^3.0.2",
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.0.5"
+  }
+}

--- a/packages/event-store-react-native/readme.md
+++ b/packages/event-store-react-native/readme.md
@@ -1,0 +1,26 @@
+# @schemeless/event-store-react-native
+
+React Native compatible build of the [`@schemeless/event-store`](../event-store) runtime. It mirrors the Node.js implementation but swaps the internal queue implementation to [`react-native-better-queue`](https://github.com/YahyaASadiq/react-native-better-queue) so it can run inside React Native apps without relying on Node.js file system primitives.
+
+## Usage
+
+Install the package from npm and initialise it the same way you would the Node.js runtime:
+
+```ts
+import { makeEventStore } from '@schemeless/event-store-react-native';
+```
+
+All public APIs match the original package, so existing event flows and adapters can be reused. The only difference is the queue dependency, which now targets React Native environments.
+
+## Development
+
+This package is generated from the Node.js implementation and will be kept in sync as part of the monorepo. Build scripts and test commands mirror the original package:
+
+```bash
+yarn workspace @schemeless/event-store-react-native compile
+yarn workspace @schemeless/event-store-react-native test
+```
+
+## License
+
+MIT

--- a/packages/event-store-react-native/src/EventStore.types.ts
+++ b/packages/event-store-react-native/src/EventStore.types.ts
@@ -1,0 +1,30 @@
+import type { Observable } from 'rxjs';
+import type {
+  CreatedEvent,
+  EventObserverState,
+  EventOutputState,
+  IEventStoreRepo,
+  SideEffectsState,
+} from '@schemeless/event-store-types';
+
+import { makeMainQueue } from './queue/makeMainQueue';
+import { makeReceive } from './queue/makeReceive';
+import { makeReplay } from './makeReplay';
+import { makeSideEffectQueue } from './queue/makeSideEffectQueue';
+
+export interface EventOutput<Payload = any> {
+  state: SideEffectsState | EventOutputState | EventObserverState;
+  error?: Error;
+  event: CreatedEvent<Payload>;
+}
+
+export interface EventStore {
+  mainQueue: ReturnType<typeof makeMainQueue>;
+  sideEffectQueue: ReturnType<typeof makeSideEffectQueue>;
+  receive: ReturnType<typeof makeReceive>;
+  replay: ReturnType<typeof makeReplay>;
+  eventStoreRepo: IEventStoreRepo;
+  output$: Observable<EventOutput>;
+}
+
+export * from '@schemeless/event-store-types';

--- a/packages/event-store-react-native/src/eventLifeCycle/apply.ts
+++ b/packages/event-store-react-native/src/eventLifeCycle/apply.ts
@@ -1,0 +1,8 @@
+import type { CreatedEvent, EventFlow } from '@schemeless/event-store-types';
+import { logEvent } from '../util/logEvent';
+
+export const apply = async (eventFlow: EventFlow<any>, event: CreatedEvent<any>): Promise<void> => {
+  logEvent(event, '✅️', 'Apply');
+  if (!eventFlow.apply) return;
+  return eventFlow.apply(event);
+};

--- a/packages/event-store-react-native/src/eventLifeCycle/createConsequentEvents.ts
+++ b/packages/event-store-react-native/src/eventLifeCycle/createConsequentEvents.ts
@@ -1,0 +1,19 @@
+import * as R from 'ramda';
+import type { BaseEvent, CreatedEvent, EventFlowMap } from '@schemeless/event-store-types';
+import { logEvent } from '../util/logEvent';
+import { getEventFlow } from '../operators/getEventFlow';
+
+export const makeCreateConsequentEventInputs =
+  (eventFlowMap: EventFlowMap) =>
+  async (event: CreatedEvent<any>): Promise<{ consequentEvents: BaseEvent<any>[]; event: CreatedEvent<any> }> => {
+    const eventFlow = getEventFlow(eventFlowMap)(event);
+    const consequentEvents: BaseEvent<any>[] = eventFlow.createConsequentEvents
+      ? await eventFlow.createConsequentEvents(event)
+      : [];
+    if (consequentEvents.length) {
+      logEvent(event, '🏭', 'subEvents', consequentEvents.map(R.prop('type')));
+    } else {
+      logEvent(event, '👌️', 'noSub');
+    }
+    return { consequentEvents, event };
+  };

--- a/packages/event-store-react-native/src/eventLifeCycle/makeValidateAndApply.ts
+++ b/packages/event-store-react-native/src/eventLifeCycle/makeValidateAndApply.ts
@@ -1,0 +1,15 @@
+import type { CreatedEvent, EventFlowMap } from '@schemeless/event-store-types';
+import { getEventFlow } from '../operators/getEventFlow';
+import { apply } from './apply';
+import { validate } from './validate';
+import { preApply } from './preApply';
+
+export const makeValidateAndApply =
+  (eventFlowMap: EventFlowMap) =>
+  async (event): Promise<CreatedEvent<any>> => {
+    const eventFlow = getEventFlow(eventFlowMap)(event);
+    await validate(eventFlow, event);
+    const preAppliedEvent = await preApply(eventFlow, event);
+    await apply(eventFlow, preAppliedEvent);
+    return preAppliedEvent;
+  };

--- a/packages/event-store-react-native/src/eventLifeCycle/preApply.ts
+++ b/packages/event-store-react-native/src/eventLifeCycle/preApply.ts
@@ -1,0 +1,9 @@
+import type { CreatedEvent, EventFlow } from '@schemeless/event-store-types';
+import { logEvent } from '../util/logEvent';
+
+export const preApply = async (eventFlow: EventFlow<any>, event: CreatedEvent<any>): Promise<CreatedEvent<any>> => {
+  logEvent(event, '🪁️', 'PreApply');
+  if (!eventFlow.preApply) return event;
+  const remakeEvent = await eventFlow.preApply(event);
+  return remakeEvent || event;
+};

--- a/packages/event-store-react-native/src/eventLifeCycle/validate.test.ts
+++ b/packages/event-store-react-native/src/eventLifeCycle/validate.test.ts
@@ -1,0 +1,23 @@
+import { validate } from './validate';
+import { StandardEvent } from '../mocks';
+import { defaultEventCreator } from '../operators/defaultEventCreator';
+
+describe('validateEvent', () => {
+  it('should throw an error on invalid', () => {
+    const event = defaultEventCreator({
+      domain: StandardEvent.domain,
+      type: StandardEvent.type,
+      payload: { key: 'validateEvent1', positiveNumber: -1 },
+    });
+    expect(validate(StandardEvent, event)).rejects.toThrow(/Invalid positive number/);
+  });
+
+  it('should not throw an error on valid', () => {
+    const event = defaultEventCreator({
+      domain: StandardEvent.domain,
+      type: StandardEvent.type,
+      payload: { key: 'validateEvent2', positiveNumber: 1 },
+    });
+    expect(() => validate(StandardEvent, event)).not.toThrow();
+  });
+});

--- a/packages/event-store-react-native/src/eventLifeCycle/validate.ts
+++ b/packages/event-store-react-native/src/eventLifeCycle/validate.ts
@@ -1,0 +1,13 @@
+import { logEvent } from '../util/logEvent';
+import type { CreatedEvent, EventFlow } from '@schemeless/event-store-types';
+
+export const validate = async (eventFlow: EventFlow<any>, event: CreatedEvent<any>): Promise<void> => {
+  try {
+    const error = eventFlow.validate ? await eventFlow.validate(event) : undefined;
+    if (error instanceof Error) throw error;
+  } catch (error) {
+    logEvent(event, '⚠️', 'unverified', error.message);
+    throw error;
+  }
+  logEvent(event, '☑️', 'verified');
+};

--- a/packages/event-store-react-native/src/index.ts
+++ b/packages/event-store-react-native/src/index.ts
@@ -1,0 +1,3 @@
+export * from './EventStore.types';
+export * from './makeEventStore';
+export { sideEffectFinishedPromise } from './util/sideEffectFinishedPromise';

--- a/packages/event-store-react-native/src/makeEventStore.test.ts
+++ b/packages/event-store-react-native/src/makeEventStore.test.ts
@@ -1,0 +1,118 @@
+import { getTestEventStore } from './util/testHelpers';
+import { NestedTwiceEvent, StandardEvent, testEventFlows, testObservers } from './mocks';
+import { storeGet } from './mocks/mockStore';
+import { mockObserverApply } from './mocks/Standard.observer';
+import delay from 'delay.ts';
+import { sideEffectFinishedPromise } from './util/sideEffectFinishedPromise';
+
+describe('make eventStore', () => {
+  beforeEach(() => jest.clearAllMocks());
+  it('should process simple events', async () => {
+    const eventStore = await getTestEventStore(testEventFlows, testObservers);
+
+    await expect(
+      StandardEvent.receive(eventStore)({
+        payload: {
+          key: 'eventStore1',
+          positiveNumber: 1,
+        },
+      })
+    ).resolves.toHaveLength(1);
+
+    expect(storeGet('eventStore1')).toBe(1);
+    await delay(100);
+    expect(mockObserverApply.mock.calls.length).toBe(1);
+  });
+
+  it('should reject invalid events', async () => {
+    const eventStore = await getTestEventStore(testEventFlows, testObservers);
+
+    await expect(
+      StandardEvent.receive(eventStore)({
+        payload: {
+          key: 'eventStore2',
+          positiveNumber: -1,
+        },
+      })
+    ).rejects.toThrowError(/Invalid positive number/);
+
+    expect(storeGet('eventStore2')).toBeUndefined();
+    expect(mockObserverApply.mock.calls.length).toBe(0);
+  });
+
+  it('should process complex events', async () => {
+    const eventStore = await getTestEventStore(testEventFlows, testObservers);
+    const events = await NestedTwiceEvent.receive(eventStore)({
+      payload: {
+        key: 'eventStore3',
+        positiveNumber: 4,
+      },
+    });
+    await expect(events).toHaveLength(7); // 1 NestedTwice, 2 NestedOnce, 4 Standard
+
+    await delay(100);
+    expect(storeGet('eventStore3')).toBe(18);
+    expect(mockObserverApply.mock.calls.length).toBe(6);
+  });
+
+  it('should cancel done events when invalid', async () => {
+    const eventStore = await getTestEventStore(testEventFlows, testObservers);
+
+    await expect(
+      NestedTwiceEvent.receive(eventStore)({
+        payload: {
+          key: 'eventStore4',
+          positiveNumber: 1,
+        },
+      })
+    ).rejects.toThrowError(/Invalid positive number/);
+
+    expect(storeGet('eventStore4')).toBe(0);
+    expect(mockObserverApply.mock.calls.length).toBe(0);
+  });
+
+  it('should have a sign to drain side effect queue', async () => {
+    const eventStore = await getTestEventStore(testEventFlows, testObservers);
+
+    const p1 = NestedTwiceEvent.receive(eventStore)({
+      payload: {
+        key: 'eventStore5',
+        positiveNumber: 4,
+      },
+    });
+
+    await delay(10);
+
+    await p1;
+
+    await sideEffectFinishedPromise(eventStore);
+
+    expect(storeGet('eventStore5')).toBe(18);
+  });
+
+  it('should process events exactly once when multiple subscribers listen to output$', async () => {
+    const eventStore = await getTestEventStore(testEventFlows, testObservers);
+    const observed: any[] = [];
+    const subscription = eventStore.output$.subscribe((entry) => {
+      if (entry.event.payload?.key === 'eventStore-multi-sub') {
+        observed.push(entry);
+      }
+    });
+
+    try {
+      await StandardEvent.receive(eventStore)({
+        payload: {
+          key: 'eventStore-multi-sub',
+          positiveNumber: 3,
+        },
+      });
+
+      await delay(100);
+
+      expect(storeGet('eventStore-multi-sub')).toBe(3);
+      expect(observed.length).toBeGreaterThan(0);
+    } finally {
+      subscription.unsubscribe();
+    }
+  });
+});

--- a/packages/event-store-react-native/src/makeEventStore.ts
+++ b/packages/event-store-react-native/src/makeEventStore.ts
@@ -1,0 +1,68 @@
+import * as Rx from 'rxjs/operators';
+import {
+  CreatedEvent,
+  EventFlow,
+  EventOutputState,
+  EventTaskAndError,
+  IEventStoreRepo,
+  SuccessEventObserver,
+} from '@schemeless/event-store-types';
+import { makeMainQueue } from './queue/makeMainQueue';
+import { makeReceive } from './queue/makeReceive';
+import { makeReplay } from './makeReplay';
+import { makeSideEffectQueue } from './queue/makeSideEffectQueue';
+import { from, merge } from 'rxjs';
+import { EventStore } from './EventStore.types';
+
+export const makeEventStore =
+  (eventStoreRepo: IEventStoreRepo) =>
+  async (eventFlows: EventFlow[], successEventObservers: SuccessEventObserver<any>[] = []): Promise<EventStore> => {
+    const mainQueue = makeMainQueue(eventFlows);
+    const sideEffectQueue = makeSideEffectQueue(eventFlows, mainQueue);
+
+    await eventStoreRepo.init();
+
+    const mainQueueProcessed$ = mainQueue.processed$.pipe(
+      Rx.concatMap(async ([doneEvents, eventTaskAndError]): Promise<[CreatedEvent<any>[], EventTaskAndError]> => {
+        if (!eventTaskAndError) {
+          await eventStoreRepo.storeEvents(doneEvents);
+          doneEvents.forEach((event) => sideEffectQueue.push({ event, retryCount: 0 }));
+          return [doneEvents, eventTaskAndError];
+        } else {
+          // todo store failed event
+          return [doneEvents, eventTaskAndError];
+        }
+      }),
+      Rx.mergeMap(([doneEvents, eventTaskAndError]) => {
+        if (!eventTaskAndError) {
+          return from(
+            doneEvents.map((e) => ({
+              event: e,
+              state: EventOutputState.success,
+            }))
+          );
+        } else {
+          return from(
+            [{ event: eventTaskAndError.task, state: EventOutputState.invalid, error: eventTaskAndError.error }].concat(
+              doneEvents.map((e) => ({ event: e, state: EventOutputState.canceled, error: undefined }))
+            )
+          );
+        }
+      })
+    );
+
+    const doneAndSideEffect$ = merge(mainQueueProcessed$, sideEffectQueue.processed$).pipe(Rx.share());
+    // const { result$, observerQueue } = assignObserver(doneAndSideEffect$, successEventObservers);
+    const output$ = doneAndSideEffect$;
+    // Ensure queues start draining even if callers only subscribe later.
+    output$.subscribe(() => undefined);
+
+    return {
+      mainQueue,
+      sideEffectQueue,
+      receive: makeReceive(mainQueue, successEventObservers),
+      replay: makeReplay(eventFlows, successEventObservers, eventStoreRepo),
+      eventStoreRepo: eventStoreRepo,
+      output$,
+    };
+  };

--- a/packages/event-store-react-native/src/makeReplay.test.ts
+++ b/packages/event-store-react-native/src/makeReplay.test.ts
@@ -1,0 +1,75 @@
+import { Subject } from 'rxjs';
+
+import type { SuccessEventObserver } from '@schemeless/event-store-types';
+
+import { makeReplay } from './makeReplay';
+import { makeObserverQueue } from './queue/makeObserverQueue';
+
+jest.mock('./queue/makeObserverQueue');
+
+const makeObserverQueueMock = makeObserverQueue as jest.MockedFunction<typeof makeObserverQueue>;
+
+describe('makeReplay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const buildIterator = (events: any[][]) =>
+    (async function* () {
+      for (const page of events) {
+        yield page;
+      }
+    })();
+
+  it('replays events using the registered event flows', async () => {
+    const apply = jest.fn().mockResolvedValue(undefined);
+    const eventFlow = {
+      domain: 'user',
+      type: 'created',
+      apply,
+    };
+
+    const successObserver: SuccessEventObserver<any> = {
+      filters: [{ domain: 'user', type: 'created' }],
+      priority: 0,
+      apply: jest.fn(),
+    };
+
+    const observerQueueDrained$ = new Subject<void>();
+    const observerPush = jest.fn(() => {
+      observerQueueDrained$.next();
+    });
+
+    makeObserverQueueMock.mockReturnValue({
+      processed$: new Subject(),
+      queueInstance: { drained$: observerQueueDrained$ } as any,
+      push: observerPush as any,
+    } as any);
+
+    const storedEvent = {
+      id: 'evt-1',
+      domain: 'user',
+      type: 'created',
+      payload: { name: 'Ada' },
+      created: new Date('2020-01-01T00:00:00.000Z').toISOString(),
+    };
+
+    const repo = {
+      getAllEvents: jest.fn(async () => buildIterator([[storedEvent], []])),
+    };
+
+    const replay = makeReplay([eventFlow as any], [successObserver], repo as any);
+
+    await replay('start-id');
+
+    expect(repo.getAllEvents).toHaveBeenCalledWith(200, 'start-id');
+    expect(apply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'evt-1',
+        created: expect.any(Date),
+      })
+    );
+    expect(makeObserverQueueMock).toHaveBeenCalledWith([successObserver]);
+    expect(observerPush).toHaveBeenCalledWith(expect.objectContaining({ id: 'evt-1' }));
+  });
+});

--- a/packages/event-store-react-native/src/makeReplay.ts
+++ b/packages/event-store-react-native/src/makeReplay.ts
@@ -1,0 +1,37 @@
+import type { CreatedEvent, EventFlow, IEventStoreRepo } from '@schemeless/event-store-types';
+import { registerEventFlowTypes } from './operators/registerEventFlowTypes';
+import { logger } from './util/logger';
+import { getEventFlow } from './operators/getEventFlow';
+import { logEvent } from './util/logEvent';
+import { SuccessEventObserver } from '@schemeless/event-store-types';
+import { makeObserverQueue } from './queue/makeObserverQueue';
+
+export const makeReplay =
+  (eventFlows: EventFlow[], successEventObservers: SuccessEventObserver<any>[] = [], eventStoreRepo: IEventStoreRepo) =>
+  async (startFromId?: string) => {
+    const eventFlowMap = registerEventFlowTypes({}, eventFlows);
+    let pageSize = 200;
+    logger.info('replay starting');
+    const eventStoreIterator = await eventStoreRepo.getAllEvents(pageSize, startFromId);
+    const observerQueue = makeObserverQueue(successEventObservers);
+    const subscription = observerQueue.processed$.subscribe();
+    observerQueue.queueInstance.drained$.subscribe(() => logger.debug(`observerQueue drained`));
+    for await (const events of eventStoreIterator) {
+      if (events.length > 0) {
+        logger.info(`replaying ${events.length}`);
+        await events.reduce<Promise<any>>(async (acc, currentEvent) => {
+          if (acc) await acc;
+          Object.assign(currentEvent, { created: new Date(currentEvent.created) });
+          const EventFlow = getEventFlow(eventFlowMap)(currentEvent);
+          logEvent(currentEvent as CreatedEvent<any>, '✅️️', 'Apply');
+          if (EventFlow.apply) {
+            await EventFlow.apply(currentEvent as CreatedEvent<any>);
+          }
+          observerQueue.push(currentEvent as CreatedEvent<any>);
+        }, null);
+      } else {
+        logger.info(`replay apply done, waiting for observer finished`);
+        break;
+      }
+    }
+  };

--- a/packages/event-store-react-native/src/mocks/FailSideEffect.event.ts
+++ b/packages/event-store-react-native/src/mocks/FailSideEffect.event.ts
@@ -1,0 +1,38 @@
+import type { CreatedEvent, EventFlow } from '@schemeless/event-store-types';
+import { storeGet } from './mockStore';
+
+const DOMAIN = 'test';
+const TYPE = 'failSideEffect';
+
+interface Payload {
+  key: string;
+  positiveNumber: number;
+}
+
+export const FailsSideEffectEvent: EventFlow<Payload> = {
+  domain: DOMAIN,
+  type: TYPE,
+  samplePayload: {
+    key: '1',
+    positiveNumber: 1,
+  },
+
+  meta: {
+    sideEffectFailedRetryAllowed: 3,
+  },
+
+  async validate(event: CreatedEvent<Payload>) {
+    if (event.payload.positiveNumber < 0) {
+      return new Error(`Invalid positive number`);
+    }
+  },
+
+  async sideEffect(event: CreatedEvent<Payload>) {
+    const num = storeGet(event.payload.key);
+    if (num < 0) {
+      throw new Error(`sideEffect Error`);
+    }
+  },
+
+  receive: (eventStore) => (eventInputArgs) => eventStore.receive(FailsSideEffectEvent)(eventInputArgs),
+};

--- a/packages/event-store-react-native/src/mocks/NestedOnce.event.ts
+++ b/packages/event-store-react-native/src/mocks/NestedOnce.event.ts
@@ -1,0 +1,54 @@
+import type { BaseEvent, BaseEventInput, CreatedEvent, EventFlow, StoredEvent } from '@schemeless/event-store-types';
+import { StandardEvent } from './Standard.event';
+import { storeGet, storeSet } from './mockStore';
+
+const DOMAIN = 'test';
+const TYPE = 'nestedOnce';
+
+interface Payload {
+  key: string;
+  positiveNumber: number;
+}
+
+export const NestedOnceEvent: EventFlow<Payload> = {
+  domain: DOMAIN,
+  type: TYPE,
+  samplePayload: {
+    key: 'a',
+    positiveNumber: 1,
+  },
+
+  async validate(event: CreatedEvent<Payload>) {
+    if (event.payload.positiveNumber < 0) {
+      throw new Error(`Invalid positive number`);
+    }
+  },
+
+  createConsequentEvents(causalEvent) {
+    const standardEvent: BaseEvent<typeof StandardEvent.samplePayload> = {
+      domain: StandardEvent.domain,
+      type: StandardEvent.type,
+      payload: {
+        key: causalEvent.payload.key,
+        positiveNumber: causalEvent.payload.positiveNumber - 1,
+      },
+    };
+    return [standardEvent, standardEvent];
+  },
+
+  async apply(event: CreatedEvent<Payload>) {
+    const num = storeGet(event.payload.key) || 0;
+    storeSet(event.payload.key, num + event.payload.positiveNumber);
+  },
+
+  cancelApply(event: CreatedEvent<Payload>) {
+    const num = storeGet(event.payload.key) || 0;
+    storeSet(event.payload.key, num - event.payload.positiveNumber);
+  },
+
+  sideEffect(event: CreatedEvent<Payload>) {
+    console.log('sideEffect called');
+  },
+
+  receive: (eventStore) => (eventInputArgs) => eventStore.receive(NestedOnceEvent)(eventInputArgs),
+};

--- a/packages/event-store-react-native/src/mocks/NestedTwice.event.ts
+++ b/packages/event-store-react-native/src/mocks/NestedTwice.event.ts
@@ -1,0 +1,58 @@
+import type { BaseEvent, CreatedEvent, EventFlow } from '@schemeless/event-store-types';
+import { NestedOnceEvent } from './NestedOnce.event';
+import { storeGet, storeSet } from './mockStore';
+
+const testObject = {
+  sum: 0,
+};
+
+const DOMAIN = 'test';
+const TYPE = 'nestedTwice';
+
+interface Payload {
+  key: string;
+  positiveNumber: number;
+}
+
+export const NestedTwiceEvent: EventFlow<Payload> = {
+  domain: DOMAIN,
+  type: TYPE,
+  samplePayload: {
+    key: 's',
+    positiveNumber: 1,
+  },
+
+  async validate(event: CreatedEvent<Payload>) {
+    if (event.payload.positiveNumber < 0) {
+      throw new Error(`Invalid positive number`);
+    }
+  },
+
+  createConsequentEvents(causalEvent) {
+    const nestedOnceEvent: BaseEvent<typeof NestedOnceEvent.samplePayload> = {
+      domain: NestedOnceEvent.domain,
+      type: NestedOnceEvent.type,
+      payload: {
+        key: causalEvent.payload.key,
+        positiveNumber: causalEvent.payload.positiveNumber - 1,
+      },
+    };
+    return [nestedOnceEvent, nestedOnceEvent];
+  },
+
+  async apply(event: CreatedEvent<Payload>) {
+    const num = storeGet(event.payload.key) || 0;
+    storeSet(event.payload.key, num + event.payload.positiveNumber);
+  },
+
+  cancelApply(event: CreatedEvent<Payload>) {
+    const num = storeGet(event.payload.key) || 0;
+    storeSet(event.payload.key, num - event.payload.positiveNumber);
+  },
+
+  sideEffect(event: CreatedEvent<Payload>) {
+    console.log('sideEffect called');
+  },
+
+  receive: (eventStore) => (eventInputArgs) => eventStore.receive(NestedTwiceEvent)(eventInputArgs),
+};

--- a/packages/event-store-react-native/src/mocks/Standard.event.ts
+++ b/packages/event-store-react-native/src/mocks/Standard.event.ts
@@ -1,0 +1,48 @@
+import type { CreatedEvent, EventFlow } from '@schemeless/event-store-types';
+import { storeGet, storeSet } from './mockStore';
+
+const DOMAIN = 'test';
+const TYPE = 'standard';
+
+interface Payload {
+  key: string;
+  positiveNumber: number;
+}
+
+function wait(ms = 1000, value = null) {
+  return new Promise((resolve) => setTimeout(resolve, ms, value));
+}
+
+export const StandardEvent: EventFlow<Payload> = {
+  domain: DOMAIN,
+  type: TYPE,
+  samplePayload: {
+    key: 's',
+    positiveNumber: 1,
+  },
+
+  async validate(event: CreatedEvent<Payload>) {
+    if (event.payload.positiveNumber < 0) {
+      return new Error(`Invalid positive number`);
+    }
+  },
+
+  async apply(event: CreatedEvent<Payload>) {
+    await wait(10);
+    const num = storeGet(event.payload.key) || 0;
+    storeSet(event.payload.key, num + event.payload.positiveNumber);
+  },
+
+  cancelApply(event: CreatedEvent<Payload>) {
+    const num = storeGet(event.payload.key) || 0;
+    storeSet(event.payload.key, num - event.payload.positiveNumber);
+  },
+
+  sideEffect(event: CreatedEvent<Payload>) {
+    console.log('sideEffect called');
+  },
+
+  receive: (eventStore) => (eventInputArgs) => {
+    return eventStore.receive(StandardEvent)(eventInputArgs);
+  },
+};

--- a/packages/event-store-react-native/src/mocks/Standard.observer.ts
+++ b/packages/event-store-react-native/src/mocks/Standard.observer.ts
@@ -1,0 +1,14 @@
+import type { SuccessEventObserver } from '@schemeless/event-store-types';
+import { StandardEvent } from './Standard.event';
+import { NestedOnceEvent } from './NestedOnce.event';
+export const mockObserverApply = jest.fn();
+
+export const StandardObserver: SuccessEventObserver<
+  typeof StandardEvent.payloadType | typeof NestedOnceEvent.payloadType
+> = {
+  filters: [StandardEvent, NestedOnceEvent],
+  priority: 1,
+  apply: (event) => {
+    mockObserverApply();
+  },
+};

--- a/packages/event-store-react-native/src/mocks/index.ts
+++ b/packages/event-store-react-native/src/mocks/index.ts
@@ -1,0 +1,19 @@
+import { StandardEvent } from './Standard.event';
+import { NestedOnceEvent } from './NestedOnce.event';
+import { NestedTwiceEvent } from './NestedTwice.event';
+import { StandardObserver } from './Standard.observer';
+export { StandardEvent } from './Standard.event';
+export { NestedOnceEvent } from './NestedOnce.event';
+export { NestedTwiceEvent } from './NestedTwice.event';
+export { StandardObserver } from './Standard.observer';
+import type { EventFlow, SuccessEventObserver } from '@schemeless/event-store-types';
+import { FailsSideEffectEvent } from './FailSideEffect.event';
+
+export const testEventFlows: EventFlow<any>[] = [
+  StandardEvent,
+  NestedOnceEvent,
+  NestedTwiceEvent,
+  FailsSideEffectEvent,
+];
+
+export const testObservers: SuccessEventObserver<any>[] = [StandardObserver];

--- a/packages/event-store-react-native/src/mocks/mockStore.ts
+++ b/packages/event-store-react-native/src/mocks/mockStore.ts
@@ -1,0 +1,9 @@
+interface Store {
+  [key: string]: number;
+}
+
+let store: Store = {};
+
+export const storeSet = (key: string, num: number) => (store[key] = num);
+
+export const storeGet = (key: string) => store[key];

--- a/packages/event-store-react-native/src/operators/applyRootEventAndCollectSucceed.ts
+++ b/packages/event-store-react-native/src/operators/applyRootEventAndCollectSucceed.ts
@@ -1,0 +1,34 @@
+import type { CreatedEvent, EventFlowMap, EventTaskAndError } from '@schemeless/event-store-types';
+import { defaultEventCreator } from './defaultEventCreator';
+import * as Rx from 'rxjs/operators';
+import { ApplyQueue } from '../queue/RxQueue';
+import { makeValidateAndApply } from '../eventLifeCycle/makeValidateAndApply';
+import { makeCreateConsequentEventInputs } from '../eventLifeCycle/createConsequentEvents';
+import { isEventTaskError } from './isEventTaskError';
+
+const applyRootEvent =
+  (eventFlowMap: EventFlowMap, applyQueue: ApplyQueue) =>
+  async ({ task, done: applyQueueDone }, drained) => {
+    const createdEvent = defaultEventCreator(task.currentEvent, task.causalEvent);
+    try {
+      const preAppliedEvent = await makeValidateAndApply(eventFlowMap)(createdEvent);
+      const { consequentEvents } = await makeCreateConsequentEventInputs(eventFlowMap)(preAppliedEvent);
+      consequentEvents.forEach((currentEvent) => {
+        applyQueue.push({ currentEvent, causalEvent: preAppliedEvent });
+      });
+      applyQueueDone(null, preAppliedEvent);
+      return preAppliedEvent;
+    } catch (e) {
+      applyQueueDone({ task: createdEvent, error: e });
+      return { task: createdEvent, error: e } as EventTaskAndError;
+    }
+  };
+
+export const applyRootEventAndCollectSucceed = (eventFlowMap: EventFlowMap, applyQueue: ApplyQueue) =>
+  applyQueue.process$.pipe(
+    Rx.mergeMap(applyRootEvent(eventFlowMap, applyQueue)),
+    Rx.scan(
+      (acc, eventOrError: EventTaskAndError) => (isEventTaskError(eventOrError) ? acc : [...acc, eventOrError]),
+      [] as CreatedEvent<any>[]
+    )
+  );

--- a/packages/event-store-react-native/src/operators/cleanupAndCancelFailedEvent.ts
+++ b/packages/event-store-react-native/src/operators/cleanupAndCancelFailedEvent.ts
@@ -1,0 +1,37 @@
+import type { BaseEvent, CreatedEvent, EventFlowMap } from '@schemeless/event-store-types';
+import * as Queue from 'better-queue';
+import { from, of, pipe } from 'rxjs';
+import * as Rx from 'rxjs/operators';
+import { getEventFlow } from './getEventFlow';
+import { logEvent } from '../util/logEvent';
+
+const cancelEvent = (eventFlowMap: EventFlowMap) => async (event: CreatedEvent<any>) => {
+  const eventFlow = getEventFlow(eventFlowMap)(event);
+  if (eventFlow.cancelApply) {
+    logEvent(event, '❌', 'cancel');
+    await eventFlow.cancelApply(event);
+  } else {
+    logEvent(event, '🤔️', 'noCancel?');
+  }
+  return event;
+};
+
+export const cleanupAndCancelFailedEvent = (
+  eventFlowMap: EventFlowMap,
+  done: Queue.ProcessFunctionCb<any>,
+  event: BaseEvent<any>
+) =>
+  pipe(
+    // call event canceler if failed
+    Rx.concatMap(([doneEvents, eventTaskAndError]) => {
+      if (eventTaskAndError && doneEvents.length > 0) {
+        return of(doneEvents).pipe(
+          Rx.concatMap((events) => from(events).pipe(Rx.mergeMap(cancelEvent(eventFlowMap)))),
+          Rx.mapTo([doneEvents, eventTaskAndError])
+        );
+      } else {
+        return of([doneEvents, eventTaskAndError]);
+      }
+    }),
+    Rx.tap(([doneEvents, eventTaskAndError]) => done(eventTaskAndError, doneEvents))
+  );

--- a/packages/event-store-react-native/src/operators/defaultEventCreator.test.ts
+++ b/packages/event-store-react-native/src/operators/defaultEventCreator.test.ts
@@ -1,0 +1,14 @@
+import { defaultEventCreator } from './defaultEventCreator';
+
+describe('defaultEventCreator', () => {
+  it('uses provided causationId when no causal event is supplied', () => {
+    const event = defaultEventCreator({
+      domain: 'Test',
+      type: 'TestEvent',
+      payload: { value: 1 },
+      causationId: 'manual-id',
+    });
+
+    expect(event.causationId).toBe('manual-id');
+  });
+});

--- a/packages/event-store-react-native/src/operators/defaultEventCreator.ts
+++ b/packages/event-store-react-native/src/operators/defaultEventCreator.ts
@@ -1,0 +1,23 @@
+import type { BaseEvent, CreatedEvent } from '@schemeless/event-store-types';
+import { getUlid } from '../util/ulid';
+
+const dateDefault = (date: string | Date | undefined): Date => {
+  if (!date) return new Date();
+  return typeof date === 'string' ? new Date(date) : date;
+};
+
+export function defaultEventCreator<Payload>(
+  eventArgs: BaseEvent<Payload>,
+  causalEvent?: CreatedEvent<any>
+): CreatedEvent<Payload> {
+  const id = getUlid();
+  return {
+    ...eventArgs,
+    id,
+    causationId: eventArgs.causationId ?? (causalEvent ? causalEvent.id : undefined),
+    correlationId: eventArgs.correlationId || (causalEvent ? causalEvent.correlationId || causalEvent.id : id),
+    identifier: eventArgs.identifier || (causalEvent ? causalEvent.identifier : undefined),
+
+    created: dateDefault(eventArgs.created),
+  };
+}

--- a/packages/event-store-react-native/src/operators/getEventFlow.ts
+++ b/packages/event-store-react-native/src/operators/getEventFlow.ts
@@ -1,0 +1,14 @@
+import type { BaseEvent, EventFlow, EventFlowMap } from '@schemeless/event-store-types';
+
+// logger.info(`🚥 🎢 |${event.correlationId?.substr(-4) || '----'}|${event.causationId?.substr(-4) || '----'}|${event.refId.substr(-4)}|flow processing\t|${event.domain}__${event.action}: `);
+export const getEventFlow =
+  (eventFlowMap: EventFlowMap) =>
+  (event: BaseEvent<any, any>): EventFlow<any> => {
+    const getEventKey = (event: BaseEvent<any, any>) => event.domain + '__' + event.type;
+    const key = getEventKey(event);
+    const eventFlow = eventFlowMap[key];
+    if (!eventFlow) {
+      throw new Error(`Event Flow (${key}) not found`);
+    }
+    return eventFlow;
+  };

--- a/packages/event-store-react-native/src/operators/isEventTaskError.ts
+++ b/packages/event-store-react-native/src/operators/isEventTaskError.ts
@@ -1,0 +1,5 @@
+import type { CreatedEvent, EventTaskAndError } from '@schemeless/event-store-types';
+
+export const isEventTaskError = (
+  eventOrError: CreatedEvent<any> | EventTaskAndError
+): eventOrError is EventTaskAndError => (eventOrError as EventTaskAndError).error != null;

--- a/packages/event-store-react-native/src/operators/racedQueueFailedOrDrained.ts
+++ b/packages/event-store-react-native/src/operators/racedQueueFailedOrDrained.ts
@@ -1,0 +1,12 @@
+import type { CreatedEvent, EventTaskAndError } from '@schemeless/event-store-types';
+import { ApplyQueue } from '../queue/RxQueue';
+import { Observable, of, race } from 'rxjs';
+import * as Rx from 'rxjs/operators';
+import { isEventTaskError } from './isEventTaskError';
+
+export const racedQueueFailedOrDrained = (applyQueue: ApplyQueue): Observable<EventTaskAndError | null> =>
+  race([applyQueue.drained$, applyQueue.taskFailed$.pipe(Rx.catchError((err) => of(err)))]).pipe(
+    Rx.map((_: CreatedEvent<any, undefined> | EventTaskAndError) =>
+      isEventTaskError(_) ? (_ as EventTaskAndError) : null
+    )
+  );

--- a/packages/event-store-react-native/src/operators/registerEventFlowTypes.ts
+++ b/packages/event-store-react-native/src/operators/registerEventFlowTypes.ts
@@ -1,0 +1,18 @@
+import type { EventFlow, EventFlowMap } from '@schemeless/event-store-types';
+
+const getEventFlowKey = (eventFlow: EventFlow<any>) => {
+  if (!eventFlow.domain) throw new Error(`EventFlow domain is not defined. type: ${eventFlow.type}`);
+  if (!eventFlow.type) throw new Error(`EventFlow type is not defined. domain: ${eventFlow.domain}`);
+  return eventFlow.domain + '__' + eventFlow.type;
+};
+
+const registerEventFlowType = (eventFlowMap: EventFlowMap, eventFlow: EventFlow<any>) => {
+  const key = getEventFlowKey(eventFlow);
+  if (!!eventFlowMap[key]) {
+    throw new Error(`Event Flow (${key}) is already registered.`);
+  }
+  return Object.assign({}, eventFlowMap, { [key]: eventFlow });
+};
+
+export const registerEventFlowTypes = (eventFlowMap: EventFlowMap, eventFlows: EventFlow<any>[]) =>
+  eventFlows.reduce((lastMap, currentEventFlow) => registerEventFlowType(lastMap, currentEventFlow), eventFlowMap);

--- a/packages/event-store-react-native/src/queue/RxQueue.test.ts
+++ b/packages/event-store-react-native/src/queue/RxQueue.test.ts
@@ -1,0 +1,107 @@
+import { createRxQueue } from './RxQueue';
+import { of, zip } from 'rxjs';
+import * as Rx from 'rxjs/operators';
+
+describe('Rx Queue', () => {
+  it('should run work on done and task', (cb) => {
+    const rxQueue = createRxQueue<number>('test');
+    zip(rxQueue.task$, rxQueue.done$).subscribe(([task, done]) => {
+      done(null, task);
+    });
+    rxQueue.push(1, () => {
+      cb();
+    });
+  });
+
+  it('should allow push and down', (cb) => {
+    const rxQueue = createRxQueue<string, string>('pushTest');
+    const taskVal = 'taskVal';
+    const resultVal = 'resultVal';
+    rxQueue.process$.subscribe(({ task, done }) => {
+      expect(task).toBe(taskVal);
+      done(null, resultVal);
+    });
+    rxQueue.push(taskVal, (err, result) => {
+      expect(err).toBeNull();
+      expect(result).toBe(resultVal);
+      cb();
+    });
+  });
+
+  it('should receive drain ', (cb) => {
+    const rxQueue = createRxQueue<string, string>('drainTest');
+    rxQueue.process$.subscribe(({ task, done }) => {
+      done();
+    });
+
+    rxQueue.push('1');
+    rxQueue.push('2');
+    rxQueue.push('3');
+
+    rxQueue.drained$.subscribe(([queue]) => {
+      expect(queue.getStats().total).toBe(3);
+      cb();
+    });
+  });
+
+  it('should receive empty ', (cb) => {
+    const rxQueue = createRxQueue<string, string>('emptyTest');
+    rxQueue.process$.subscribe(({ task, done }) => {
+      done();
+    });
+
+    rxQueue.push('1');
+    rxQueue.push('2');
+    rxQueue.push('3');
+
+    rxQueue.empty$.subscribe(([queue]) => {
+      expect(queue.getStats().total).toBe(3);
+      cb();
+    });
+  });
+
+  it('should receive failed ', (cb) => {
+    const rxQueue = createRxQueue<string, string>('failedTest');
+    rxQueue.process$.subscribe(({ task, done }) => {
+      done('failed');
+    });
+
+    rxQueue.push('1');
+    rxQueue.push('2');
+    rxQueue.push('3');
+
+    rxQueue.taskFailed$
+      .pipe(
+        Rx.catchError((err, caught) => {
+          expect(err).toBe('failed');
+          return of('done');
+        })
+      )
+      .subscribe((end) => {
+        expect(end).toBe('done');
+        cb();
+      });
+  });
+
+  it('should be able to get queue size', async () => {
+    const rxQueue = createRxQueue<string, string>('basicTest');
+
+    rxQueue.process$.subscribe(({ task, done }) => {
+      done();
+    });
+
+    let arr = [];
+    rxQueue.queueSize$.subscribe((size) => {
+      arr.push(size);
+    });
+
+    rxQueue.push('1');
+    rxQueue.push('2');
+    rxQueue.push('3');
+
+    const delay = (ms) => new Promise((res) => setTimeout(res, ms));
+    await delay(20);
+
+    expect(arr).toEqual([null, 1, 2, 3, 2, 1, 0]);
+  });
+});

--- a/packages/event-store-react-native/src/queue/RxQueue.ts
+++ b/packages/event-store-react-native/src/queue/RxQueue.ts
@@ -1,0 +1,80 @@
+import * as Queue from 'react-native-better-queue';
+import { ProcessFunction } from 'react-native-better-queue';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { logger } from '../util/logger';
+import * as Rx from 'rxjs/operators';
+import * as R from 'ramda';
+import { scan } from 'ramda';
+
+const makeEventQueueObservable = <TASK, RESULT, RETURN = [Queue<TASK, RESULT>]>(
+  queue: Queue<TASK, RESULT>,
+  queueEventType: Queue.QueueEvent,
+  queueId = 'unnamed'
+): Observable<RETURN> => {
+  return new Observable<RETURN>((observer) => {
+    queue.on(queueEventType, (...args) => {
+      logger.debug(`Queue Event: ${queueId} - ${queueEventType}`);
+      observer.next(args.length === 0 ? [queue] : ([queue, ...args] as any));
+    });
+  });
+};
+
+const makeFailedEventQueueObservable = <TASK, RESULT, RETURN = [Queue<TASK, RESULT>]>(
+  queue: Queue<TASK, RESULT>
+): Observable<RETURN> => {
+  return new Observable<RETURN>((observer) => {
+    queue.on('task_failed', (id, error) => {
+      logger.warn('EventQueueObservable error');
+      // logger.fatal('%o', error);
+      observer.error(error);
+    });
+  });
+};
+
+const makeQueue = <TASK, RESULT>(
+  fn: ProcessFunction<TASK, RESULT>,
+  queueOptions: Omit<Queue.QueueOptions<TASK, RESULT>, 'process'>
+) => new Queue<TASK, RESULT>(fn, queueOptions);
+
+export type ApplyQueue = ReturnType<typeof createRxQueue>;
+
+export const createRxQueue = <TASK = any, RESULT = TASK>(
+  id: string,
+  queueOptions?: Omit<Queue.QueueOptions<TASK, RESULT>, 'process'>
+) => {
+  const process$ = new Subject<{ task: TASK; done: Queue.ProcessFunctionCb<RESULT> }>();
+  const callback: Queue.ProcessFunction<TASK, RESULT> = (task, done) => {
+    process$.next({ task, done });
+  };
+
+  const queueSizeInput$ = new Subject<number>();
+  const queueSizeOutput$ = new BehaviorSubject<number | null>(null);
+
+  queueSizeInput$.pipe(Rx.scan((acc, curr) => (acc || 0) + curr, null)).subscribe(queueSizeOutput$);
+
+  const customPush = (task: any, cb?: (err: any, result: any) => void) => {
+    queueSizeInput$.next(+1);
+    queue
+      .push(task, cb)
+      .on('finish', () => {
+        queueSizeInput$.next(-1);
+      })
+      .on('failed', () => {
+        queueSizeInput$.next(-1);
+      });
+  };
+
+  const queue = makeQueue<TASK, RESULT>(callback, Object.assign(queueOptions || {}, { id: id }));
+  return {
+    id,
+    queueInstance: queue,
+    push: customPush as typeof queue.push,
+    process$,
+    task$: process$.pipe(Rx.map(R.prop('task'))),
+    done$: process$.pipe(Rx.map(R.prop('done'))),
+    drained$: makeEventQueueObservable<TASK, RESULT>(queue, 'drain', id),
+    empty$: makeEventQueueObservable<TASK, RESULT>(queue, 'empty', id),
+    taskFailed$: makeFailedEventQueueObservable<TASK, RESULT>(queue),
+    queueSize$: queueSizeOutput$,
+  };
+};

--- a/packages/event-store-react-native/src/queue/makeApplyQueue.ts
+++ b/packages/event-store-react-native/src/queue/makeApplyQueue.ts
@@ -1,0 +1,12 @@
+import { createRxQueue } from './RxQueue';
+import type { BaseEvent, CreatedEvent } from '@schemeless/event-store-types';
+import { v4 as uuid } from 'uuid';
+
+export const makeApplyQueue = () =>
+  createRxQueue<{ causalEvent?: CreatedEvent<any>; currentEvent: BaseEvent<any> }, CreatedEvent<any>>(
+    'apply:' + uuid().substr(-4, 4),
+    {
+      filo: true,
+      concurrent: 1,
+    }
+  );

--- a/packages/event-store-react-native/src/queue/makeMainQueue.test.ts
+++ b/packages/event-store-react-native/src/queue/makeMainQueue.test.ts
@@ -1,0 +1,26 @@
+import { makeMainQueue } from './makeMainQueue';
+import { StandardEvent } from '../mocks/Standard.event';
+import { NestedOnceEvent } from '../mocks/NestedOnce.event';
+import { NestedTwiceEvent } from '../mocks/NestedTwice.event';
+
+describe('Main Queue', () => {
+  it('should run', (cb) => {
+    const mainQueue = makeMainQueue([StandardEvent, NestedOnceEvent, NestedTwiceEvent]);
+    mainQueue.processed$.subscribe();
+    mainQueue.push({
+      domain: NestedTwiceEvent.domain,
+      type: NestedTwiceEvent.type,
+      payload: { key: 'MainQueue1', positiveNumber: 1 },
+    });
+    mainQueue.push(
+      {
+        domain: NestedOnceEvent.domain,
+        type: NestedOnceEvent.type,
+        payload: { key: 'MainQueue2', positiveNumber: 1 },
+      },
+      (err, result) => {
+        cb();
+      }
+    );
+  });
+});

--- a/packages/event-store-react-native/src/queue/makeMainQueue.ts
+++ b/packages/event-store-react-native/src/queue/makeMainQueue.ts
@@ -1,0 +1,40 @@
+import { createRxQueue } from './RxQueue';
+import * as Rx from 'rxjs/operators';
+import type { BaseEvent, CreatedEvent, EventFlow, EventTaskAndError } from '@schemeless/event-store-types';
+import { combineLatest, Observable } from 'rxjs';
+import { logEvent } from '../util/logEvent';
+import { registerEventFlowTypes } from '../operators/registerEventFlowTypes';
+import { applyRootEventAndCollectSucceed } from '../operators/applyRootEventAndCollectSucceed';
+import { cleanupAndCancelFailedEvent } from '../operators/cleanupAndCancelFailedEvent';
+import { racedQueueFailedOrDrained } from '../operators/racedQueueFailedOrDrained';
+import { makeApplyQueue } from './makeApplyQueue';
+
+export const makeMainQueue = (eventFlows: EventFlow<any>[]) => {
+  const mainQueue = createRxQueue<BaseEvent<any>, any>('main', { concurrent: 1 });
+  const eventFlowMap = registerEventFlowTypes({}, eventFlows);
+
+  const processed$ = mainQueue.process$.pipe(
+    Rx.concatMap(({ task, done: mainQueueDone }) => {
+      const applyQueue = makeApplyQueue();
+      logEvent(task, '✨', 'received');
+      applyQueue.push({ currentEvent: task });
+      return combineLatest([
+        applyRootEventAndCollectSucceed(eventFlowMap, applyQueue),
+        racedQueueFailedOrDrained(applyQueue),
+      ]).pipe(
+        Rx.take(1),
+        cleanupAndCancelFailedEvent(eventFlowMap, mainQueueDone, task),
+        Rx.tap(() => applyQueue.queueInstance.destroy(() => undefined)),
+        Rx.tap(() => logEvent(task, '🏁', 'finished'))
+      );
+    })
+  ) as Observable<[CreatedEvent<any>[], EventTaskAndError]>;
+
+  return {
+    processed$,
+    queueInstance: mainQueue,
+    push: mainQueue.push.bind(mainQueue) as typeof mainQueue.push,
+  };
+};
+
+export type mainQueueType = ReturnType<typeof makeMainQueue>;

--- a/packages/event-store-react-native/src/queue/makeObserverQueue.test.ts
+++ b/packages/event-store-react-native/src/queue/makeObserverQueue.test.ts
@@ -1,0 +1,78 @@
+import { firstValueFrom } from 'rxjs';
+
+import type { CreatedEvent, SuccessEventObserver } from '@schemeless/event-store-types';
+import { EventObserverState } from '@schemeless/event-store-types';
+
+import { makeObserverQueue } from './makeObserverQueue';
+
+const makeEvent = (): CreatedEvent<any> => ({
+  id: '1',
+  domain: 'test',
+  type: 'created',
+  payload: {},
+  created: new Date(),
+});
+
+describe('makeObserverQueue', () => {
+  it('applies matching observers and emits success states', async () => {
+    const apply = jest.fn().mockResolvedValue(undefined);
+    const observers: SuccessEventObserver<any>[] = [
+      {
+        filters: [{ domain: 'test', type: 'created' }],
+        priority: 10,
+        apply,
+      },
+    ];
+
+    const observerQueue = makeObserverQueue(observers);
+    const processedPromise = firstValueFrom(observerQueue.processed$);
+    const drainedPromise = firstValueFrom(observerQueue.queueInstance.drained$);
+
+    const event = makeEvent();
+    observerQueue.push(event);
+
+    const result = await processedPromise;
+    await drainedPromise;
+
+    expect(apply).toHaveBeenCalledWith(event);
+    expect(result).toEqual({ event, state: EventObserverState.success });
+  });
+
+  it('respects observer priority when applying multiple observers', async () => {
+    const callOrder: string[] = [];
+    const lowPriority: SuccessEventObserver<any> = {
+      filters: [{ domain: 'test', type: 'created' }],
+      priority: 10,
+      apply: jest.fn(async () => {
+        callOrder.push('low');
+      }),
+    };
+    const highPriority: SuccessEventObserver<any> = {
+      filters: [{ domain: 'test', type: 'created' }],
+      priority: 1,
+      apply: jest.fn(async () => {
+        callOrder.push('high');
+      }),
+    };
+
+    const observerQueue = makeObserverQueue([lowPriority, highPriority]);
+    const processedPromise = firstValueFrom(observerQueue.processed$);
+
+    observerQueue.push(makeEvent());
+    await processedPromise;
+
+    expect(callOrder).toEqual(['high', 'low']);
+  });
+
+  it('drains without emitting when no observers match', async () => {
+    const observerQueue = makeObserverQueue([]);
+    const processedSpy = jest.fn();
+    const subscription = observerQueue.processed$.subscribe(processedSpy);
+
+    observerQueue.push(makeEvent());
+    await firstValueFrom(observerQueue.queueInstance.drained$);
+
+    expect(processedSpy).not.toHaveBeenCalled();
+    subscription.unsubscribe();
+  });
+});

--- a/packages/event-store-react-native/src/queue/makeObserverQueue.ts
+++ b/packages/event-store-react-native/src/queue/makeObserverQueue.ts
@@ -1,0 +1,58 @@
+import { CreatedEvent, EventObserverState, SuccessEventObserver } from '@schemeless/event-store-types';
+import { createRxQueue } from './RxQueue';
+import * as R from 'ramda';
+import * as Rx from 'rxjs/operators';
+import { logEvent } from '../util/logEvent';
+import { Observable } from 'rxjs';
+import { EventOutput } from '../EventStore.types';
+
+type ObserverMap = { [domainType: string]: SuccessEventObserver[] };
+
+const makeObserverMap = (successEventObservers: SuccessEventObserver[]) => {
+  const observerMap: ObserverMap = successEventObservers.reduce((acc, observer) => {
+    observer.filters.forEach((filter) => {
+      const domainType = filter.domain + '__' + filter.type;
+      const savedObservers = acc[domainType] || [];
+      acc[domainType] = [...savedObservers, observer];
+    });
+    return acc;
+  }, {});
+
+  return observerMap;
+};
+
+export const makeObserverQueue = (successEventObservers: SuccessEventObserver<any>[]) => {
+  const observerQueue = createRxQueue<CreatedEvent<any>, any>('applySuccessEventObservers', {
+    concurrent: 1,
+  });
+
+  const observerMap = makeObserverMap(successEventObservers);
+
+  const processed$: Observable<EventOutput> = observerQueue.process$.pipe(
+    Rx.mergeMap(async ({ done, task: createdEvent }) => {
+      const thisDomainType = createdEvent.domain + '__' + createdEvent.type;
+      const observersToApply = observerMap[thisDomainType];
+      if (!observersToApply || observersToApply.length === 0) {
+        logEvent(createdEvent, '👀', 'No observers to apply');
+        done();
+        return null;
+      } else {
+        // apply observers
+        const orderedObserversToApply = R.sortBy(R.prop('priority'))(observersToApply);
+        for (const observerToApply of orderedObserversToApply) {
+          await observerToApply.apply(createdEvent);
+        }
+        logEvent(createdEvent, '👀', 'Applied observers');
+        done();
+        return { state: EventObserverState.success, event: createdEvent };
+      }
+    }),
+    Rx.filter((r) => !!r)
+  );
+
+  return {
+    processed$,
+    queueInstance: observerQueue,
+    push: observerQueue.push.bind(observerQueue) as typeof observerQueue.push,
+  };
+};

--- a/packages/event-store-react-native/src/queue/makeReceive.test.ts
+++ b/packages/event-store-react-native/src/queue/makeReceive.test.ts
@@ -1,0 +1,78 @@
+import { Subject } from 'rxjs';
+
+import type { BaseEventInput, SuccessEventObserver } from '@schemeless/event-store-types';
+
+import { makeReceive } from './makeReceive';
+import { makeObserverQueue } from './makeObserverQueue';
+
+jest.mock('./makeObserverQueue');
+
+const makeObserverQueueMock = makeObserverQueue as jest.MockedFunction<typeof makeObserverQueue>;
+
+const eventFlow = {
+  domain: 'account',
+  type: 'created',
+};
+
+const eventInput: BaseEventInput<{ id: string }> = {
+  payload: { id: '42' },
+};
+
+describe('makeReceive', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('pushes events to the main queue and waits for observer completion', async () => {
+    const drained$ = new Subject<void>();
+    const observerPush = jest.fn();
+    makeObserverQueueMock.mockReturnValue({
+      processed$: new Subject(),
+      queueInstance: { drained$ } as any,
+      push: observerPush as any,
+    } as any);
+
+    const successObservers: SuccessEventObserver<any>[] = [
+      { filters: [{ domain: 'account', type: 'created' }], priority: 0, apply: jest.fn() },
+    ];
+
+    const doneEvents = [
+      { id: '1', domain: 'account', type: 'created', payload: { id: '42' }, created: new Date() },
+    ] as any;
+
+    const mainQueue = {
+      push: jest.fn((event, cb) => {
+        cb(null, doneEvents);
+      }),
+    };
+
+    const receive = makeReceive(mainQueue as any, successObservers);
+
+    const receivePromise = receive(eventFlow as any)(eventInput);
+
+    expect(mainQueue.push).toHaveBeenCalledWith(
+      expect.objectContaining({ domain: 'account', type: 'created' }),
+      expect.any(Function)
+    );
+    expect(makeObserverQueueMock).toHaveBeenCalledWith(successObservers);
+
+    drained$.next();
+
+    await expect(receivePromise).resolves.toEqual(doneEvents);
+    expect(observerPush).toHaveBeenCalledTimes(doneEvents.length);
+    expect(observerPush).toHaveBeenCalledWith(doneEvents[0]);
+  });
+
+  it('rejects when the main queue reports an error', async () => {
+    const mainQueue = {
+      push: jest.fn((_, cb) => {
+        cb({ error: new Error('broken') } as any, undefined as any);
+      }),
+    };
+
+    const receive = makeReceive(mainQueue as any, []);
+
+    await expect(receive(eventFlow as any)(eventInput)).rejects.toThrow('broken');
+    expect(makeObserverQueueMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/event-store-react-native/src/queue/makeReceive.ts
+++ b/packages/event-store-react-native/src/queue/makeReceive.ts
@@ -1,0 +1,30 @@
+import type { BaseEventInput, CreatedEvent, EventFlow, EventTaskAndError } from '@schemeless/event-store-types';
+import { makeMainQueue } from './makeMainQueue';
+import { makeObserverQueue } from './makeObserverQueue';
+import { SuccessEventObserver } from '@schemeless/event-store-types';
+
+export const makeReceive =
+  (mainQueue: ReturnType<typeof makeMainQueue>, successEventObservers: SuccessEventObserver<any>[] = []) =>
+  <PartialPayload, Payload extends PartialPayload>(eventFlow: EventFlow<PartialPayload, Payload>) =>
+  (eventInput: BaseEventInput<PartialPayload>): Promise<[CreatedEvent<Payload>, ...Array<CreatedEvent<any>>]> => {
+    const event = Object.assign({}, eventInput, {
+      domain: eventFlow.domain,
+      type: eventFlow.type,
+      created: eventInput.created || undefined,
+    });
+    return new Promise((resolve, reject) => {
+      mainQueue.push(
+        event,
+        (err: EventTaskAndError, doneEvents: [CreatedEvent<Payload>, ...Array<CreatedEvent<any>>]) => {
+          if (err) {
+            reject(err.error);
+          } else {
+            const observerQueue = makeObserverQueue(successEventObservers);
+            observerQueue.processed$.subscribe();
+            observerQueue.queueInstance.drained$.subscribe(() => resolve(doneEvents));
+            doneEvents.forEach((event) => observerQueue.push(event));
+          }
+        }
+      );
+    });
+  };

--- a/packages/event-store-react-native/src/queue/makeSideEffectQueue.test.ts
+++ b/packages/event-store-react-native/src/queue/makeSideEffectQueue.test.ts
@@ -1,0 +1,66 @@
+import { SideEffectsState } from '@schemeless/event-store-types';
+import { makeSideEffectQueue } from './makeSideEffectQueue';
+import { FailsSideEffectEvent } from '../mocks/FailSideEffect.event';
+import { defaultEventCreator } from '../operators/defaultEventCreator';
+import { storeSet } from '../mocks/mockStore';
+import { mainQueueType } from './makeMainQueue';
+
+const spy = jest.spyOn(FailsSideEffectEvent, 'sideEffect');
+const mainQueuePush = jest.fn();
+
+describe('makeSideEffectQueue', () => {
+  it('should retry until fail', (cb) => {
+    spy.mockClear();
+    const sideEffectQueue = makeSideEffectQueue([FailsSideEffectEvent], {
+      push: mainQueuePush,
+    } as unknown as mainQueueType);
+    sideEffectQueue.processed$.subscribe((r) => {
+      if (r.state === SideEffectsState.fail) {
+        expect(spy).toBeCalledTimes(4);
+        cb();
+      }
+    });
+    storeSet('a', -1);
+    sideEffectQueue.push({
+      retryCount: 0,
+      event: defaultEventCreator({
+        domain: FailsSideEffectEvent.domain,
+        type: FailsSideEffectEvent.type,
+        payload: {
+          key: 'a',
+          positiveNumber: 1,
+        },
+      }),
+    });
+  });
+
+  it('should stop retry when success', (cb) => {
+    spy.mockClear();
+    const sideEffectQueue = makeSideEffectQueue([FailsSideEffectEvent], {
+      push: mainQueuePush,
+    } as unknown as mainQueueType);
+    sideEffectQueue.processed$.subscribe((r) => {
+      if (r.state === SideEffectsState.done) {
+        expect(spy).toBeCalledTimes(2);
+        cb();
+      }
+    });
+    storeSet('b', -1);
+    sideEffectQueue.push(
+      {
+        retryCount: 0,
+        event: defaultEventCreator({
+          domain: FailsSideEffectEvent.domain,
+          type: FailsSideEffectEvent.type,
+          payload: {
+            key: 'b',
+            positiveNumber: 1,
+          },
+        }),
+      },
+      () => {
+        storeSet('b', 1);
+      }
+    );
+  });
+});

--- a/packages/event-store-react-native/src/queue/makeSideEffectQueue.ts
+++ b/packages/event-store-react-native/src/queue/makeSideEffectQueue.ts
@@ -1,0 +1,58 @@
+import { BaseEvent, CreatedEvent, EventFlow, SideEffectsState } from '@schemeless/event-store-types';
+import { createRxQueue } from './RxQueue';
+import { registerEventFlowTypes } from '../operators/registerEventFlowTypes';
+import * as Rx from 'rxjs/operators';
+import { logEvent } from '../util/logEvent';
+import { getEventFlow } from '../operators/getEventFlow';
+import { logger } from '../util/logger';
+import { mainQueueType } from './makeMainQueue';
+
+export const makeSideEffectQueue = (eventFlows: EventFlow[], mainQueue: mainQueueType) => {
+  const sideEffectQueue = createRxQueue<{ retryCount: number; event: CreatedEvent<any> }, any>('sideEffect', {
+    concurrent: 1,
+  });
+  const eventFlowMap = registerEventFlowTypes({}, eventFlows);
+
+  const processed$ = sideEffectQueue.process$.pipe(
+    Rx.mergeMap(
+      async ({ task: { retryCount, event }, done }): Promise<{ state: SideEffectsState; event: CreatedEvent<any> }> => {
+        const eventFlow: EventFlow = getEventFlow(eventFlowMap)(event);
+        if (!eventFlow.sideEffect) {
+          logEvent(event, '🌠', 'SideEffect:N/A');
+          done();
+          return { event, state: SideEffectsState.done };
+        } else {
+          try {
+            const nextEvents: BaseEvent<any>[] = (await eventFlow.sideEffect(event)) as unknown as BaseEvent<any>[];
+            logEvent(event, '🌠', 'SideEffect:Done');
+            if (nextEvents?.length) {
+              nextEvents.forEach((nextEvent) => {
+                mainQueue.push(nextEvent);
+              });
+            }
+            done();
+            return { event, state: SideEffectsState.done };
+          } catch (error) {
+            logger.error(error.toString());
+            const sideEffectFailedRetryAllowed = eventFlow.meta?.sideEffectFailedRetryAllowed;
+            if (sideEffectFailedRetryAllowed && retryCount < sideEffectFailedRetryAllowed) {
+              logEvent(event, '🌠', 'SE:Retry:' + retryCount);
+              sideEffectQueue.push({ retryCount: retryCount + 1, event });
+              done();
+              return { event, state: SideEffectsState.retry };
+            } else {
+              logEvent(event, '🌠', 'SE:FAILED:' + retryCount);
+              done();
+              return { event, state: SideEffectsState.fail };
+            }
+          }
+        }
+      }
+    )
+  );
+  return {
+    processed$,
+    queueInstance: sideEffectQueue,
+    push: sideEffectQueue.push.bind(sideEffectQueue) as typeof sideEffectQueue.push,
+  };
+};

--- a/packages/event-store-react-native/src/types/react-native-better-queue.d.ts
+++ b/packages/event-store-react-native/src/types/react-native-better-queue.d.ts
@@ -1,0 +1,4 @@
+declare module 'react-native-better-queue' {
+  import Queue = require('better-queue');
+  export = Queue;
+}

--- a/packages/event-store-react-native/src/util/completeOn.operator.test.ts
+++ b/packages/event-store-react-native/src/util/completeOn.operator.test.ts
@@ -1,0 +1,22 @@
+import { lastValueFrom, of, throwError } from 'rxjs';
+import { toArray } from 'rxjs/operators';
+
+import { completeOn } from './completeOn.operator';
+
+describe('completeOn operator', () => {
+  it('completes after receiving the same terminal queue size twice', async () => {
+    const emissions = await lastValueFrom(of(3, 2, 1, 0, 0).pipe(completeOn(), toArray()));
+
+    expect(emissions).toEqual([3, 2, 1, 0]);
+  });
+
+  it('continues emitting when repeated values are not terminal', async () => {
+    const emissions = await lastValueFrom(of(1, 1, 2, 0, 0, 1).pipe(completeOn(), toArray()));
+
+    expect(emissions).toEqual([1, 1, 2, 0]);
+  });
+
+  it('propagates source errors', async () => {
+    await expect(lastValueFrom(throwError(() => new Error('boom')).pipe(completeOn()))).rejects.toThrow('boom');
+  });
+});

--- a/packages/event-store-react-native/src/util/completeOn.operator.ts
+++ b/packages/event-store-react-native/src/util/completeOn.operator.ts
@@ -1,0 +1,30 @@
+import { Observable, of } from 'rxjs';
+
+export function completeOn<T>() {
+  return (observable: Observable<T>) =>
+    new Observable<T>((subscriber) => {
+      let lastNum: undefined | null | T = undefined;
+      const subscription = observable.subscribe({
+        next(value) {
+          if (lastNum === value && (lastNum === null || lastNum === 0)) {
+            subscriber.complete();
+          } else {
+            lastNum = value;
+            subscriber.next(value);
+          }
+        },
+        error(err) {
+          subscriber.error(err);
+        },
+        complete() {
+          subscriber.complete();
+        },
+      });
+
+      // Return the finalization logic. This will be invoked when
+      // the result errors, completes, or is unsubscribed.
+      return () => {
+        subscription.unsubscribe();
+      };
+    });
+}

--- a/packages/event-store-react-native/src/util/logEvent.ts
+++ b/packages/event-store-react-native/src/util/logEvent.ts
@@ -1,0 +1,13 @@
+import { logger } from './logger';
+import type { BaseEvent } from '@schemeless/event-store-types';
+
+const trimId = (str: string | null | undefined) => (str || '----').substr(-4);
+
+export const logEvent = (event: BaseEvent<any>, icon: string, text: string, ...moreArgs) => {
+  logger.info(
+    `📦 ${icon.trim()} |` +
+      `${event.domain}:${event.type}`.padEnd(25) +
+      `|${text.padEnd(12)} |ID:${trimId(event.id)}|COR:${trimId(event.correlationId)}|CAU:${trimId(event.causationId)}`,
+    ...moreArgs
+  );
+};

--- a/packages/event-store-react-native/src/util/logger.ts
+++ b/packages/event-store-react-native/src/util/logger.ts
@@ -1,0 +1,15 @@
+import _debug from 'debug';
+const debug = _debug('schemeless:event-store');
+const logFunc =
+  (level: string) =>
+  (str: string, ...args) =>
+    debug(level.padEnd(5) + ':' + str, ...args);
+
+export const logger = {
+  fatal: logFunc('fatal'),
+  error: logFunc('error'),
+  warn: logFunc('warn'),
+  info: logFunc('info'),
+  debug: logFunc('debug'),
+  trace: logFunc('trace'),
+};

--- a/packages/event-store-react-native/src/util/sideEffectFinishedPromise.test.ts
+++ b/packages/event-store-react-native/src/util/sideEffectFinishedPromise.test.ts
@@ -1,0 +1,61 @@
+import { BehaviorSubject } from 'rxjs';
+
+import { sideEffectFinishedPromise } from './sideEffectFinishedPromise';
+
+describe('sideEffectFinishedPromise', () => {
+  const tick = async () => {
+    jest.advanceTimersByTime(100);
+    await Promise.resolve();
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('resolves once the queue reports empty twice in a row', async () => {
+    const queueSize$ = new BehaviorSubject<number | null>(3);
+    const eventStore = {
+      sideEffectQueue: {
+        queueInstance: {
+          queueSize$,
+        },
+      },
+    } as any;
+
+    const finishedPromise = sideEffectFinishedPromise(eventStore);
+
+    await tick();
+    queueSize$.next(1);
+    await tick();
+    queueSize$.next(0);
+    await tick();
+
+    const waitForCompletion = finishedPromise;
+
+    await tick();
+
+    await expect(waitForCompletion).resolves.toBe(0);
+  });
+
+  it('handles null queue sizes', async () => {
+    const queueSize$ = new BehaviorSubject<number | null>(null);
+    const eventStore = {
+      sideEffectQueue: {
+        queueInstance: {
+          queueSize$,
+        },
+      },
+    } as any;
+
+    const waitForCompletion = sideEffectFinishedPromise(eventStore);
+
+    await tick();
+    await tick();
+
+    await expect(waitForCompletion).resolves.toBeNull();
+  });
+});

--- a/packages/event-store-react-native/src/util/sideEffectFinishedPromise.ts
+++ b/packages/event-store-react-native/src/util/sideEffectFinishedPromise.ts
@@ -1,0 +1,12 @@
+import { EventStore } from '../EventStore.types';
+import { combineLatest, interval, lastValueFrom } from 'rxjs';
+import * as Rx from 'rxjs/operators';
+import { completeOn } from './completeOn.operator';
+
+export const sideEffectFinishedPromise = (eventStore: EventStore) =>
+  lastValueFrom(
+    combineLatest<[number, number | null]>([interval(100), eventStore.sideEffectQueue.queueInstance.queueSize$]).pipe(
+      Rx.map(([_, num]) => num),
+      completeOn()
+    )
+  );

--- a/packages/event-store-react-native/src/util/testHelpers.ts
+++ b/packages/event-store-react-native/src/util/testHelpers.ts
@@ -1,0 +1,38 @@
+import type { EventFlow, SuccessEventObserver } from '@schemeless/event-store-types';
+import { EventStoreRepo } from '@schemeless/event-store-adapter-typeorm';
+// import { EventStoreRepo } from '@schemeless/event-store-adapter-dynamodb';
+import { ConnectionOptions } from 'typeorm';
+import { makeEventStore } from '../makeEventStore';
+import { EventStore } from '../EventStore.types';
+
+const defaultInMemDBOption = {
+  type: 'sqlite',
+  database: ':memory:',
+  dropSchema: true,
+  synchronize: true,
+  logger: 'advanced-console',
+  logging: 'all',
+} as ConnectionOptions;
+
+const defaultInMenDBOptionEventSourcing: ConnectionOptions = Object.assign({}, defaultInMemDBOption, {
+  name: 'EventSourcing',
+});
+
+let eventStore: EventStore;
+
+export const getTestEventStore = async (
+  allEventFlows: EventFlow[],
+  successEventObservers: SuccessEventObserver<any>[]
+) => {
+  if (eventStore) {
+    return eventStore;
+  } else {
+    const eventStoreRepo = new EventStoreRepo(defaultInMenDBOptionEventSourcing);
+    // const eventStoreRepo = new EventStoreRepo('test', {
+    //   region: 'us-east-2',
+    //   endpoint: 'http://127.0.0.1:8000',
+    // });
+    eventStore = await makeEventStore(eventStoreRepo)(allEventFlows, successEventObservers);
+    return eventStore;
+  }
+};

--- a/packages/event-store-react-native/src/util/ulid.ts
+++ b/packages/event-store-react-native/src/util/ulid.ts
@@ -1,0 +1,9 @@
+import { monotonicFactory, ULID } from 'ulid';
+
+let ulidInstance: ULID;
+
+export const getUlid = (): string => {
+  if (ulidInstance) return ulidInstance();
+  ulidInstance = monotonicFactory();
+  return ulidInstance();
+};

--- a/packages/event-store-react-native/tsconfig.json
+++ b/packages/event-store-react-native/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "target": "es6",
+    "lib": ["es7"],
+    "module": "commonjs",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
+    "strictPropertyInitialization": false
+  },
+  "exclude": ["node_modules", "**/*.test.ts", "**/testHelpers.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ For long-running services, `replay` rehydrates projections by running stored eve
 ```
 packages/
   event-store/                 Core runtime implementation
+  event-store-react-native/    React Native build of the core runtime
   event-store-types/           Shared type definitions
   event-store-adapter-*/       Persistence implementations (Prisma, TypeORM, DynamoDB, null)
   dynamodb-orm/                AWS Data Mapper helpers

--- a/yarn.lock
+++ b/yarn.lock
@@ -3562,6 +3562,11 @@ eventemitter3@^3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -7279,6 +7284,19 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-native-better-queue@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-better-queue/-/react-native-better-queue-0.1.1.tgz#a8724f103dbcef44e6cc5b192dea671a9faab2be"
+  integrity sha512-Lyf8iMIOD441bXSupuPZ7VGpcqbkXnbC1g2zAr+R3gsxg8foUpJyiTF94rnaiLcYLA17i1Z+ockc8N29G+Ukqw==
+  dependencies:
+    eventemitter3 "^5.0.1"
+    react-native-uuid "^2.0.1"
+
+react-native-uuid@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-native-uuid/-/react-native-uuid-2.0.3.tgz#f85f8a8d68e52e3f1c18ba0f02ec7776f9d4a0da"
+  integrity sha512-f/YfIS2f5UB+gut7t/9BKGSCYbRA9/74A5R1MDp+FLYsuS+OSWoiM/D8Jko6OJB6Jcu3v6ONuddvZKHdIGpeiw==
 
 read-cmd-shim@^1.0.1:
   version "1.0.5"


### PR DESCRIPTION
## Summary
- add a new @schemeless/event-store-react-native workspace cloned from the Node.js runtime and powered by react-native-better-queue
- provide typings, jest configuration, and documentation for the React Native package including monorepo overview updates

## Testing
- yarn bootstrap
- yarn workspace @schemeless/event-store-react-native compile
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68dff002390483298539b6747002ee50