### PR TITLE
docs: add domain documentation reminder

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -26,3 +26,4 @@ These instructions apply to the entire repository.
 
 - Update `readme.md` when adding new packages, scripts, or high-level concepts so the monorepo overview stays current.
 - Keep examples under `examples/` in sync with any breaking API changes.
+- When making significant changes to code under `src/domains`, ensure the corresponding docs in `docs/domains` are updated accordingly.


### PR DESCRIPTION
## Summary
- add guidance to update docs/domains when making significant changes to src/domains code

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e681e1f2e483299e150003bf5776a8